### PR TITLE
[FEAT] 구독 만료 스케줄러 구현 및 자동 결제 파이프라인 완성

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/entity/Subscription.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/entity/Subscription.java
@@ -72,6 +72,10 @@ public class Subscription extends BaseTimeEntity {
         this.status = SubscriptionStatus.PAUSED;
     }
 
+    public void expire() {
+        this.status = SubscriptionStatus.INACTIVE;
+    }
+
     public void increaseRetryCount() {
         this.retryCount++;
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/repository/SubscriptionRepository.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/repository/SubscriptionRepository.java
@@ -21,4 +21,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     Optional<Subscription> findTopByUserIdAndStatusInOrderByCreatedAtDesc(Long userId, List<SubscriptionStatus> statuses);
 
     List<Subscription> findByStatusAndNextBillingAtLessThanEqual(SubscriptionStatus status, LocalDateTime dateTime);
+
+    List<Subscription> findByStatusAndExpiredAtLessThanEqual(SubscriptionStatus status, LocalDateTime dateTime);
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/SubscriptionExpiryScheduler.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/SubscriptionExpiryScheduler.java
@@ -1,0 +1,41 @@
+package com.keyfeed.keyfeedmonolithic.domain.payment.scheduler;
+
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.Subscription;
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
+import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscriptionExpiryScheduler {
+
+    private final SubscriptionRepository subscriptionRepository;
+
+    /**
+     * 구독 만료 스케줄러 — 매일 자정 실행
+     * status = CANCELED AND expired_at <= 현재 인 구독을 INACTIVE로 전환
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void expireSubscriptions() {
+        log.info("[구독 만료 스케줄러] 시작 - 대상 조회");
+
+        List<Subscription> expiredList = subscriptionRepository
+                .findByStatusAndExpiredAtLessThanEqual(SubscriptionStatus.CANCELED, LocalDateTime.now());
+
+        for (Subscription sub : expiredList) {
+            sub.expire();
+            log.info("[구독 만료] subscriptionId={}, userId={}", sub.getId(), sub.getUser().getId());
+        }
+
+        log.info("[구독 만료 스케줄러] {}건 INACTIVE 전환 완료", expiredList.size());
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/notification/consumer/NotificationConsumer.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/notification/consumer/NotificationConsumer.java
@@ -33,12 +33,12 @@ public class NotificationConsumer {
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
 
-//    @Scheduled(fixedDelay = 500, scheduler = "notificationConsumerScheduler")
+    @Scheduled(fixedDelay = 500, scheduler = "notificationConsumerScheduler")
     public void consume() {
         log.info("[NotificationConsumer] 컨텐츠를 소비하고 알림을 저장합니다.");
 
         String payload = redisTemplate.opsForList().rightPop(QUEUE_KEY);
-        if (payload == null) {
+    if (payload == null) {
             return;
         }
 

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/SubscriptionExpirySchedulerTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/SubscriptionExpirySchedulerTest.java
@@ -1,0 +1,120 @@
+package com.keyfeed.keyfeedmonolithic.domain.payment.scheduler;
+
+import com.keyfeed.keyfeedmonolithic.domain.auth.entity.User;
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.Subscription;
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
+import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionExpirySchedulerTest {
+
+    @InjectMocks
+    private SubscriptionExpiryScheduler subscriptionExpiryScheduler;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    // ===== expireSubscriptions =====
+
+    @Test
+    @DisplayName("만료 대상 구독 1건 INACTIVE 전환 성공")
+    void 만료_대상_구독_INACTIVE_전환_성공() {
+        // given
+        Subscription sub = makeCanceledSubscription(1L, LocalDateTime.now().minusDays(1));
+        given(subscriptionRepository.findByStatusAndExpiredAtLessThanEqual(
+                eq(SubscriptionStatus.CANCELED), any(LocalDateTime.class)))
+                .willReturn(List.of(sub));
+
+        // when
+        subscriptionExpiryScheduler.expireSubscriptions();
+
+        // then
+        assertThat(sub.getStatus()).isEqualTo(SubscriptionStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("만료 대상이 여러 건인 경우 모두 INACTIVE 전환")
+    void 만료_대상_여러건_일괄_처리() {
+        // given
+        Subscription sub1 = makeCanceledSubscription(1L, LocalDateTime.now().minusDays(1));
+        Subscription sub2 = makeCanceledSubscription(2L, LocalDateTime.now().minusDays(10));
+        Subscription sub3 = makeCanceledSubscription(3L, LocalDateTime.now().minusMonths(1));
+        given(subscriptionRepository.findByStatusAndExpiredAtLessThanEqual(
+                eq(SubscriptionStatus.CANCELED), any(LocalDateTime.class)))
+                .willReturn(List.of(sub1, sub2, sub3));
+
+        // when
+        subscriptionExpiryScheduler.expireSubscriptions();
+
+        // then
+        assertThat(sub1.getStatus()).isEqualTo(SubscriptionStatus.INACTIVE);
+        assertThat(sub2.getStatus()).isEqualTo(SubscriptionStatus.INACTIVE);
+        assertThat(sub3.getStatus()).isEqualTo(SubscriptionStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("만료 대상이 없는 경우 아무 처리 없이 정상 종료")
+    void 만료_대상_없음_정상_종료() {
+        // given
+        given(subscriptionRepository.findByStatusAndExpiredAtLessThanEqual(
+                eq(SubscriptionStatus.CANCELED), any(LocalDateTime.class)))
+                .willReturn(List.of());
+
+        // when & then
+        assertThatCode(() -> subscriptionExpiryScheduler.expireSubscriptions())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("expired_at이 미래인 구독은 처리 대상에서 제외됨")
+    void 미래_만료일_구독_처리_제외() {
+        // given - repository가 빈 리스트 반환 (미래 expired_at은 쿼리 조건에 해당 안 됨)
+        given(subscriptionRepository.findByStatusAndExpiredAtLessThanEqual(
+                eq(SubscriptionStatus.CANCELED), any(LocalDateTime.class)))
+                .willReturn(List.of());
+
+        Subscription futureSub = makeCanceledSubscription(1L, LocalDateTime.now().plusDays(30));
+
+        // when
+        subscriptionExpiryScheduler.expireSubscriptions();
+
+        // then - CANCELED 상태 그대로 유지
+        assertThat(futureSub.getStatus()).isEqualTo(SubscriptionStatus.CANCELED);
+    }
+
+    // ===== helpers =====
+
+    private User makeUser(Long id) {
+        return User.builder()
+                .id(id)
+                .email("test@test.com")
+                .username("테스터")
+                .customerKey("customer-key-" + id)
+                .build();
+    }
+
+    private Subscription makeCanceledSubscription(Long id, LocalDateTime expiredAt) {
+        User user = makeUser(id);
+        return Subscription.builder()
+                .id(id).user(user)
+                .status(SubscriptionStatus.CANCELED)
+                .price(9900).orderName("프리미엄 구독 1개월")
+                .startedAt(LocalDateTime.now().minusMonths(1))
+                .expiredAt(expiredAt)
+                .canceledAt(LocalDateTime.now().minusDays(5))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

- CANCELED 상태 구독의 만료일 도달 시 INACTIVE로 자동 전환하는 `SubscriptionExpiryScheduler` 구현
- `Subscription.expire()` 메서드 및 `findByStatusAndExpiredAtLessThanEqual` 쿼리 추가
- 실수로 주석 처리된 `NotificationConsumer` 의 `@Scheduled` 어노테이션 활성화
- `SubscriptionExpiryScheduler` 단위 테스트 작성

## Test plan

- [ ] `만료_대상_구독_INACTIVE_전환_성공` — 만료일 지난 CANCELED 구독 1건 INACTIVE 전환 확인
- [ ] `만료_대상_여러건_일괄_처리` — 복수 만료 대상 전체 INACTIVE 전환 확인
- [ ] `만료_대상_없음_정상_종료` — 대상 없을 때 예외 없이 종료 확인
- [ ] `미래_만료일_구독_처리_제외` — 만료일이 미래인 구독은 상태 변경 없음 확인