### PR TITLE
[FIX] API 요청 405 에러 해결을 위한 Nginx 프록시 설정 추가

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,6 +8,15 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    location /api/ {
+        proxy_pass http://localhost:8080; # 백엔드 서버 주소 (필요시 도메인/포트 수정)
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";


### PR DESCRIPTION
## 개요

프론트엔드에서 백엔드 API 요청 시 발생하는 405 에러를 Nginx 리버스 프록시 설정으로 해결합니다.

## 변경사항

### `frontend/nginx.conf`
- `/api/` 경로에 대한 리버스 프록시 설정 추가
- 백엔드 서버(`http://localhost:8080`)로 요청 전달
- `Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto` 헤더 전달