### PR TITLE
[FIX] API 요청 502 에러 해결을 위한 Nginx 프록시 호스트 수정

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,7 +9,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://localhost:8080; # 백엔드 서버 주소 (필요시 도메인/포트 수정)
+        proxy_pass http://keyfeed-backend:8080; # 백엔드 도커 컨테이너명
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 개요

Nginx 리버스 프록시의 `proxy_pass` 호스트를 `localhost`에서 Docker 컨테이너명으로 수정하여 502 에러를 해결합니다.

## 변경사항

### `frontend/nginx.conf`
- `proxy_pass http://localhost:8080` → `http://keyfeed-backend:8080`
- Docker 네트워크 환경에서 컨테이너 간 통신은 `localhost`가 아닌 컨테이너명으로 참조해야 함