### PR TITLE
[CI] 프론트엔드-백엔드 Docker 네트워크 연결 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,8 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            docker network create keyfeed-network || true
+
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/keyfeed-backend:latest
 
             docker stop keyfeed-backend || true
@@ -82,8 +84,8 @@ jobs:
 
             docker run -d \
               --name keyfeed-backend \
+              --network keyfeed-network \
               --restart unless-stopped \
-              -p 8080:8080 \
               -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }} \
               -e jwt_key=${{ secrets.JWT_KEY }} \
               ${{ secrets.DOCKERHUB_USERNAME }}/keyfeed-backend:latest
@@ -131,6 +133,8 @@ jobs:
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
+            docker network create keyfeed-network || true
+
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/keyfeed-frontend:latest
 
             docker stop keyfeed-frontend || true
@@ -138,6 +142,7 @@ jobs:
 
             docker run -d \
               --name keyfeed-frontend \
+              --network keyfeed-network \
               --restart unless-stopped \
               -p 80:80 \
               ${{ secrets.DOCKERHUB_USERNAME }}/keyfeed-frontend:latest

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,7 +9,11 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://keyfeed-backend:8080; # 백엔드 도커 컨테이너명
+        # Nginx 시작 시 백엔드 컨테이너가 없더라도 크래시 나지 않게 동적 DNS 확인 (Docker 내부 DNS 활용)
+        resolver 127.0.0.11 valid=30s;
+        set $backend "http://keyfeed-backend:8080";
+        proxy_pass $backend;
+
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- `deploy.yml`: 배포 시 `keyfeed-network` 생성 후 backend/frontend 컨테이너를 같은 네트워크에 연결
- `deploy.yml`: backend 컨테이너의 `-p 8080:8080` 외부 포트 노출 제거 (nginx 내부 네트워크로만 접근)
- `nginx.conf`: Docker 내부 DNS(`127.0.0.11`)를 통한 동적 업스트림 해석으로 변경 (nginx 시작 시 backend 컨테이너 미존재 크래시 방지)

## 원인
nginx가 `keyfeed-backend` 호스트명을 해석하지 못해 `host not found in upstream` 에러 발생.
backend/frontend 컨테이너가 각각 독립 실행되어 같은 Docker 네트워크에 없었기 때문.

## Test plan
- [ ] main push 후 GitHub Actions 배포 성공 확인
- [ ] EC2에서 `docker network inspect keyfeed-network`으로 두 컨테이너 연결 확인
- [ ] 프론트엔드에서 `/api/` 요청 정상 응답 확인