### PR TITLE
[FIX] 프로덕션 CORS 허용 출처 환경변수로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,7 @@ jobs:
               --restart unless-stopped \
               -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }} \
               -e jwt_key=${{ secrets.JWT_KEY }} \
+              -e CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }} \
               ${{ secrets.DOCKERHUB_USERNAME }}/keyfeed-backend:latest
 
             docker image prune -f

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -26,7 +26,7 @@ jwt:
   refresh_expiration_time: 1209600000
 
 cors:
-  allowed-origins: http://localhost:3000
+  allowed-origins: ${CORS_ALLOWED_ORIGINS}
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- `application-prod.yml`: CORS 허용 출처를 하드코딩(`http://localhost:3000`)에서 환경변수(`${CORS_ALLOWED_ORIGINS}`)로 변경
- `deploy.yml`: backend 컨테이너 실행 시 `CORS_ALLOWED_ORIGINS` 환경변수 주입 추가

## 원인
프로덕션 환경의 CORS 허용 출처가 `http://localhost:3000`으로 고정되어 있어, 배포된 프론트엔드(EC2 IP)에서 보내는 요청이 브라우저에서 CORS 정책으로 차단됨.

## 적용 방법
GitHub Secrets에 아래 값 추가 필요:
- `CORS_ALLOWED_ORIGINS`: `http://<EC2_IP>` (도메인이 있다면 콤마로 구분하여 추가)

## Test plan
- [ ] GitHub Secrets에 `CORS_ALLOWED_ORIGINS` 추가
- [ ] main 머지 후 배포 확인
- [ ] 브라우저에서 로그인 API 정상 응답 확인