### PR TITLE
[FIX] 운영 배포 시 API 기본 호스트가 localhost로 유지되는 오류 수정

### DIFF
--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,4 +1,4 @@
 export const env = {
-    apiBaseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
+    apiBaseUrl: import.meta.env.VITE_API_BASE_URL || (import.meta.env.PROD ? '' : 'http://localhost:8080'),
     appEnv: import.meta.env.VITE_APP_ENV || 'development',
 } as const;


### PR DESCRIPTION
## Summary
- 운영 환경에서 API 요청의 기본 호스트가 `localhost`로 유지되어 백엔드 연결이 실패하는 문제 수정

## Test plan
- [ ] 배포 후 프론트엔드에서 API 요청 정상 동작 확인