### PR TITLE
[CI] 백엔드 컨테이너 8080 포트 외부 노출 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,7 @@ jobs:
               --name keyfeed-backend \
               --network keyfeed-network \
               --restart unless-stopped \
+              -p 8080:8080 \
               -v /home/ubuntu/logs:/app/logs \
               -e JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }} \
               -e jwt_key=${{ secrets.JWT_KEY }} \


### PR DESCRIPTION
## Summary
- `deploy.yml`: backend 컨테이너 실행 시 `-p 8080:8080` 포트 바인딩 추가

## 배경
Postman 등 외부에서 백엔드 API를 직접 테스트할 수 있도록 EC2 호스트의 8080 포트를 컨테이너에 바인딩