### PR TITLE
[REFACTOR] NotificationConsumer 불필요한 로그 제거 및 들여쓰기 수정

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/notification/consumer/NotificationConsumer.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/notification/consumer/NotificationConsumer.java
@@ -35,10 +35,8 @@ public class NotificationConsumer {
 
     @Scheduled(fixedDelay = 500, scheduler = "notificationConsumerScheduler")
     public void consume() {
-        log.info("[NotificationConsumer] 컨텐츠를 소비하고 알림을 저장합니다.");
-
         String payload = redisTemplate.opsForList().rightPop(QUEUE_KEY);
-    if (payload == null) {
+        if (payload == null) {
             return;
         }
 
@@ -137,8 +135,7 @@ public class NotificationConsumer {
         return userMatchedKeywords;
     }
 
-    private void saveNotificationsInChunks(Map<Long, Set<String>> userMatchedKeywords,
-                                           ContentEventPayload content) {
+    private void saveNotificationsInChunks(Map<Long, Set<String>> userMatchedKeywords, ContentEventPayload content) {
         List<Long> userIds = new ArrayList<>(userMatchedKeywords.keySet());
 
         long totalInsertTime = 0;


### PR DESCRIPTION
## Summary
- `consume()` 메서드의 매 호출마다 출력되던 불필요한 로그 제거
- 잘못된 들여쓰기 수정
- `saveNotificationsInChunks()` 파라미터 줄바꿈 정리