### PR TITLE
chore(backend): HTTP 요청 백분위수 히스토그램 메트릭 설정 추가

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -42,6 +42,9 @@ management:
   metrics:
     tags:
       application: key-feed-monolithic-backend
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
## Summary
- `application-prod.yml`에 `http.server.requests` 백분위수 히스토그램 메트릭 설정 추가
- Prometheus에서 p50, p95, p99 등 응답 시간 분포를 수집할 수 있도록 함

## 관련 이슈
closes #28