### PR TITLE
[FEAT] 피드 오프셋 기반 페이징 API 추가 (테스트용)

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/content/repository/ContentRepository.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/content/repository/ContentRepository.java
@@ -1,6 +1,7 @@
 package com.keyfeed.keyfeedmonolithic.domain.content.repository;
 
 import com.keyfeed.keyfeedmonolithic.domain.content.entity.Content;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -70,6 +71,15 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
                                             @Param("lastCheckedAt") LocalDateTime lastCheckedAt,
                                             @Param("lastId") Long lastId,
                                             @Param("size") int size);
+
+    // 오프셋 기반 피드 조회 (전체 카운트 포함)
+    @Query(value = "SELECT c FROM Content c WHERE c.sourceId IN :sourceIds ORDER BY c.id DESC",
+           countQuery = "SELECT COUNT(c) FROM Content c WHERE c.sourceId IN :sourceIds")
+    Page<Content> findPageBySourceIds(@Param("sourceIds") List<Long> sourceIds, Pageable pageable);
+
+    @Query(value = "SELECT c FROM Content c WHERE c.sourceId IN :sourceIds AND (c.title LIKE %:keyword% OR c.summary LIKE %:keyword%) ORDER BY c.id DESC",
+           countQuery = "SELECT COUNT(c) FROM Content c WHERE c.sourceId IN :sourceIds AND (c.title LIKE %:keyword% OR c.summary LIKE %:keyword%)")
+    Page<Content> searchPageBySourceIds(@Param("sourceIds") List<Long> sourceIds, @Param("keyword") String keyword, Pageable pageable);
 
     // 읽지 않은 알림 수
     @Query(value = """

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/controller/FeedController.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/controller/FeedController.java
@@ -4,6 +4,7 @@ import com.keyfeed.keyfeedmonolithic.domain.content.dto.ContentFeedResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.feed.service.FeedService;
 import com.keyfeed.keyfeedmonolithic.global.response.CommonPageResponse;
 import com.keyfeed.keyfeedmonolithic.global.response.HttpResponse;
+import com.keyfeed.keyfeedmonolithic.global.response.OffsetPageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,16 @@ public class FeedController {
                                         @RequestParam(value = "size", defaultValue = "10") int size,
                                         @RequestParam(value = "keyword", required = false) String keyword) {
         CommonPageResponse<ContentFeedResponseDto> feeds = feedService.getPersonalizedFeeds(userId, lastId, size, keyword);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, READ_SUCCESS.getMessage(), feeds));
+    }
+
+    @GetMapping("/offset")
+    public ResponseEntity<?> getMyFeedsWithOffset(@AuthenticationPrincipal Long userId,
+                                                  @RequestParam(value = "page", defaultValue = "0") int page,
+                                                  @RequestParam(value = "size", defaultValue = "10") int size,
+                                                  @RequestParam(value = "keyword", required = false) String keyword) {
+        OffsetPageResponse<ContentFeedResponseDto> feeds = feedService.getPersonalizedFeedsWithOffset(userId, page, size, keyword);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, READ_SUCCESS.getMessage(), feeds));
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/FeedService.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/FeedService.java
@@ -2,9 +2,12 @@ package com.keyfeed.keyfeedmonolithic.domain.feed.service;
 
 import com.keyfeed.keyfeedmonolithic.domain.content.dto.ContentFeedResponseDto;
 import com.keyfeed.keyfeedmonolithic.global.response.CommonPageResponse;
+import com.keyfeed.keyfeedmonolithic.global.response.OffsetPageResponse;
 
 public interface FeedService {
 
     CommonPageResponse<ContentFeedResponseDto> getPersonalizedFeeds(Long userId, Long lastId, int size, String keyword);
+
+    OffsetPageResponse<ContentFeedResponseDto> getPersonalizedFeedsWithOffset(Long userId, int page, int size, String keyword);
 
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
@@ -8,8 +8,10 @@ import com.keyfeed.keyfeedmonolithic.domain.feed.service.FeedService;
 import com.keyfeed.keyfeedmonolithic.domain.source.dto.SourceResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.source.service.SourceService;
 import com.keyfeed.keyfeedmonolithic.global.response.CommonPageResponse;
+import com.keyfeed.keyfeedmonolithic.global.response.OffsetPageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -62,6 +64,45 @@ public class FeedServiceImpl implements FeedService {
                 .content(feeds)
                 .hasNext(hasNext)
                 .nextCursorId(nextCursorId)
+                .build();
+    }
+
+    @Override
+    public OffsetPageResponse<ContentFeedResponseDto> getPersonalizedFeedsWithOffset(Long userId, int page, int size, String keyword) {
+        List<SourceResponseDto> userSources = sourceService.getSourcesByUser(userId);
+        if (CollectionUtils.isEmpty(userSources)) {
+            return OffsetPageResponse.empty();
+        }
+
+        Map<Long, SourceResponseDto> sourceMap = userSources.stream()
+                .collect(Collectors.toMap(
+                        SourceResponseDto::getSourceId,
+                        source -> source,
+                        (existing, replacement) -> existing
+                ));
+
+        List<Long> sourceIds = new ArrayList<>(sourceMap.keySet());
+
+        int safeSize = Math.min(size, 50);
+        Pageable pageable = PageRequest.of(page, safeSize);
+
+        Page<Content> contentPage = StringUtils.hasText(keyword)
+                ? contentRepository.searchPageBySourceIds(sourceIds, keyword, pageable)
+                : contentRepository.findPageBySourceIds(sourceIds, pageable);
+
+        List<ContentFeedResponseDto> feeds = contentPage.getContent().stream()
+                .map(content -> ContentFeedResponseDto.from(content, sourceMap.get(content.getSourceId())))
+                .collect(Collectors.toList());
+
+        attachBookmarkStatus(userId, feeds);
+
+        return OffsetPageResponse.<ContentFeedResponseDto>builder()
+                .content(feeds)
+                .page(contentPage.getNumber())
+                .size(contentPage.getSize())
+                .totalElements(contentPage.getTotalElements())
+                .totalPages(contentPage.getTotalPages())
+                .hasNext(contentPage.hasNext())
                 .build();
     }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/response/OffsetPageResponse.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/response/OffsetPageResponse.java
@@ -1,0 +1,42 @@
+package com.keyfeed.keyfeedmonolithic.global.response;
+
+import lombok.*;
+import org.springframework.data.domain.Page;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OffsetPageResponse<T> {
+    private List<T> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+
+    public static <T> OffsetPageResponse<T> from(Page<T> page) {
+        return OffsetPageResponse.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .hasNext(page.hasNext())
+                .build();
+    }
+
+    public static <T> OffsetPageResponse<T> empty() {
+        return OffsetPageResponse.<T>builder()
+                .content(Collections.emptyList())
+                .page(0)
+                .size(0)
+                .totalElements(0L)
+                .totalPages(0)
+                .hasNext(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

- `GET /api/feed/offset` 엔드포인트 추가 — 기존 커서 방식(`GET /api/feed`)과 공존
- `OffsetPageResponse<T>` 응답 DTO 추가 (`page`, `size`, `totalElements`, `totalPages`, `hasNext`)
- `ContentRepository`에 `Page<Content>` 반환 쿼리 2개 추가 (count 쿼리 분리)

## 배경

커서 기반 페이징과 오프셋 기반 페이징의 성능 비교를 위해 두 API를 병행 운영

## API 비교

| | 커서 방식 | 오프셋 방식 |
|---|---|---|
| 엔드포인트 | `GET /api/feed?lastId=&size=` | `GET /api/feed/offset?page=&size=` |
| 응답 | `nextCursorId`, `hasNext` | `totalElements`, `totalPages`, `hasNext` |
| COUNT 쿼리 | 없음 | 있음 |

## Test plan

- [x] `GET /api/feed` 기존 커서 페이징 정상 동작 확인
- [x] `GET /api/feed/offset?page=0&size=10` 첫 페이지 응답 확인
- [x] `GET /api/feed/offset?page=1&size=10` 다음 페이지 응답 확인
- [x] `keyword` 파라미터 포함 검색 동작 확인
- [x] `totalElements`, `totalPages` 값 정합성 확인