### PR TITLE
feat(backend): 구독 여부에 따른 키워드 등록 한도 차등 적용

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -54,8 +54,7 @@ public class KeywordServiceImpl implements KeywordService {
             throw new EntityAlreadyExistsException("Keyword", name);
         }
 
-        boolean isActiveSubscriber = subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
-        if (!isActiveSubscriber && keywordRepository.countByUserId(userId) >= keywordMaxCount) {
+        if (!hasKeywordBenefit(userId) && keywordRepository.countByUserId(userId) >= keywordMaxCount) {
             throw new KeywordLimitExceededException();
         }
 
@@ -105,6 +104,11 @@ public class KeywordServiceImpl implements KeywordService {
                 .stream()
                 .map(projection -> new TrendingKeywordResponseDto(projection.getName(), projection.getUserCount()))
                 .toList();
+    }
+
+    private boolean hasKeywordBenefit(Long userId) {
+        return subscriptionRepository.existsByUserIdAndStatusIn(
+                userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED));
     }
 
     private User findUserById(Long userId) {

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -8,6 +8,8 @@ import com.keyfeed.keyfeedmonolithic.domain.keyword.entity.Keyword;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.exception.KeywordLimitExceededException;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.service.KeywordService;
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
+import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityAlreadyExistsException;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class KeywordServiceImpl implements KeywordService {
 
     private final KeywordRepository keywordRepository;
     private final UserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     @Value("${app.limits.keyword-max-count}")
     private int keywordMaxCount;
@@ -51,7 +54,8 @@ public class KeywordServiceImpl implements KeywordService {
             throw new EntityAlreadyExistsException("Keyword", name);
         }
 
-        if (keywordRepository.countByUserId(userId) >= keywordMaxCount) {
+        boolean isActiveSubscriber = subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
+        if (!isActiveSubscriber && keywordRepository.countByUserId(userId) >= keywordMaxCount) {
             throw new KeywordLimitExceededException();
         }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
@@ -32,7 +32,7 @@ public enum ErrorMessage {
     EMAIL_ALREADY_VERIFIED("이미 인증된 이메일입니다."),
 
     // keyword
-    KEYWORD_LIMIT_EXCEEDED("키워드 등록 한도를 넘었습니다."),
+    KEYWORD_LIMIT_EXCEEDED("키워드 등록 한도를 넘었습니다. 구독 시 무제한으로 이용하실 수 있습니다."),
 
     // crawl
     INVALID_RSS_URL("해당 URL에 접근할 수 없거나 유효한 웹사이트가 아닙니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -45,7 +45,7 @@ jwt:
 
 app:
   limits:
-    keyword-max-count: 20
+    keyword-max-count: 3
     folder-max-count: 7
 
 cors:

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
@@ -1,0 +1,230 @@
+package com.keyfeed.keyfeedmonolithic.domain.keyword.service.impl;
+
+import com.keyfeed.keyfeedmonolithic.domain.auth.entity.User;
+import com.keyfeed.keyfeedmonolithic.domain.auth.repository.UserRepository;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.dto.KeywordResponseDto;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.entity.Keyword;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.exception.KeywordLimitExceededException;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordRepository;
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
+import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
+import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityAlreadyExistsException;
+import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class KeywordServiceImplTest {
+
+    @InjectMocks
+    private KeywordServiceImpl keywordService;
+
+    @Mock
+    private KeywordRepository keywordRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    private static final int KEYWORD_MAX_COUNT = 3;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(keywordService, "keywordMaxCount", KEYWORD_MAX_COUNT);
+    }
+
+    private User makeUser(Long id) {
+        return User.builder()
+                .email("test@test.com")
+                .username("testUser")
+                .build();
+    }
+
+    private Keyword makeKeyword(Long id, User user, String name) {
+        return Keyword.builder()
+                .user(user)
+                .name(name)
+                .build();
+    }
+
+    @Test
+    @DisplayName("비구독자 - 한도 미만이면 키워드 추가 성공")
+    void 비구독자_한도_미만_키워드_추가_성공() {
+        // given
+        Long userId = 1L;
+        String keywordName = "스프링";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(keywordRepository.countByUserId(userId)).willReturn(2L);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+
+        // then
+        assertThat(result.getName()).isEqualTo(keywordName);
+        then(keywordRepository).should(times(1)).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("비구독자 - 한도(3개) 초과 시 KeywordLimitExceededException 발생")
+    void 비구독자_한도_초과_예외_발생() {
+        // given
+        Long userId = 2L;
+        String keywordName = "자바";
+        User user = makeUser(userId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(keywordRepository.countByUserId(userId)).willReturn(3L);
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
+                .isInstanceOf(KeywordLimitExceededException.class)
+                .hasMessageContaining("구독 시 무제한으로 이용하실 수 있습니다");
+
+        then(keywordRepository).should(never()).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("구독자(ACTIVE) - 한도 초과해도 키워드 추가 성공")
+    void 구독자_한도_초과해도_키워드_추가_성공() {
+        // given
+        Long userId = 3L;
+        String keywordName = "코틀린";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(true);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+
+        // then
+        assertThat(result.getName()).isEqualTo(keywordName);
+        then(keywordRepository).should(never()).countByUserId(userId);
+        then(keywordRepository).should(times(1)).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("구독자(ACTIVE) - 한도(100개)를 크게 초과해도 키워드 추가 성공")
+    void 구독자_대량_키워드_추가_성공() {
+        // given
+        Long userId = 4L;
+        String keywordName = "리액트";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(true);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+
+        // then
+        assertThat(result).isNotNull();
+        then(keywordRepository).should(never()).countByUserId(any());
+    }
+
+    @Test
+    @DisplayName("중복 키워드 등록 시 EntityAlreadyExistsException 발생")
+    void 중복_키워드_등록_예외_발생() {
+        // given
+        Long userId = 5L;
+        String keywordName = "중복키워드";
+        User user = makeUser(userId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
+                .isInstanceOf(EntityAlreadyExistsException.class);
+
+        then(subscriptionRepository).should(never()).existsByUserIdAndStatus(any(), any());
+        then(keywordRepository).should(never()).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 - EntityNotFoundException 발생")
+    void 존재하지_않는_사용자_예외_발생() {
+        // given
+        Long userId = 999L;
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.addKeyword(userId, "키워드"))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        then(keywordRepository).should(never()).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("비구독자 - 정확히 한도(3개)와 동일한 경우 예외 발생")
+    void 비구독자_정확히_한도_동일_예외_발생() {
+        // given
+        Long userId = 6L;
+        String keywordName = "파이썬";
+        User user = makeUser(userId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT);
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
+                .isInstanceOf(KeywordLimitExceededException.class);
+    }
+
+    @Test
+    @DisplayName("비구독자 - 한도보다 1개 적을 때 키워드 추가 성공")
+    void 비구독자_한도보다_1개_적을때_성공() {
+        // given
+        Long userId = 7L;
+        String keywordName = "도커";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT - 1);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+
+        // then
+        assertThat(result.getName()).isEqualTo(keywordName);
+    }
+}

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +77,7 @@ class KeywordServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
         given(keywordRepository.countByUserId(userId)).willReturn(2L);
         given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
 
@@ -98,7 +99,7 @@ class KeywordServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
         given(keywordRepository.countByUserId(userId)).willReturn(3L);
 
         // when & then
@@ -120,7 +121,7 @@ class KeywordServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(true);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
         given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
 
         // when
@@ -143,7 +144,7 @@ class KeywordServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(true);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
         given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
 
         // when
@@ -152,6 +153,29 @@ class KeywordServiceImplTest {
         // then
         assertThat(result).isNotNull();
         then(keywordRepository).should(never()).countByUserId(any());
+    }
+
+    @Test
+    @DisplayName("구독자(CANCELED, 만료 전) - 한도 초과해도 키워드 추가 성공")
+    void 구독_취소_만료전_한도_초과해도_키워드_추가_성공() {
+        // given
+        Long userId = 8L;
+        String keywordName = "쿠버네티스";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+
+        // then
+        assertThat(result.getName()).isEqualTo(keywordName);
+        then(keywordRepository).should(never()).countByUserId(userId);
+        then(keywordRepository).should(times(1)).save(any(Keyword.class));
     }
 
     @Test
@@ -169,7 +193,7 @@ class KeywordServiceImplTest {
         assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
                 .isInstanceOf(EntityAlreadyExistsException.class);
 
-        then(subscriptionRepository).should(never()).existsByUserIdAndStatus(any(), any());
+        then(subscriptionRepository).should(never()).existsByUserIdAndStatusIn(any(), any());
         then(keywordRepository).should(never()).save(any(Keyword.class));
     }
 
@@ -198,7 +222,7 @@ class KeywordServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
         given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT);
 
         // when & then
@@ -217,7 +241,7 @@ class KeywordServiceImplTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
         given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT - 1);
         given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
 


### PR DESCRIPTION
## Summary
- 비구독자 키워드 등록 한도를 20개 → 3개로 변경 (`app.limits.keyword-max-count`)
- 구독자(ACTIVE)는 한도 체크 없이 무제한 키워드 등록 가능
- 한도 초과 에러 메시지에 구독 유도 문구 추가

## 변경 파일
- `application.yml` - `keyword-max-count` 20 → 3
- `KeywordServiceImpl.java` - `SubscriptionRepository` 주입, 구독자 분기 추가
- `ErrorMessage.java` - `KEYWORD_LIMIT_EXCEEDED` 메시지 개선
- `KeywordServiceImplTest.java` - 구독자/비구독자 케이스 단위 테스트 추가

## 동작 방식
- 구독자(`ACTIVE`): `SubscriptionRepository.existsByUserIdAndStatus()` 로 확인 후 한도 체크 스킵
- 비구독자/취소(`CANCELED`): 3개 초과 시 `KeywordLimitExceededException` 발생
- 구독 취소 시 기존 키워드 자동 삭제 없음 (추가만 차단)

## Test plan
- [ ] 비구독자 - 한도 미만 → 키워드 추가 성공
- [ ] 비구독자 - 한도(3개) 이상 → `KeywordLimitExceededException`
- [ ] 구독자(ACTIVE) - 한도 초과해도 → 키워드 추가 성공
- [ ] 구독 취소 후 기존 키워드 유지 확인

Closes #47