### PR TITLE
[FEAT] 구독 여부에 따른 키워드/북마크 폴더 생성 한도 차등 적용

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -1304,7 +1304,7 @@ POST /api/payment-methods/register
 
 ---
 
-### 8-2. 결제 수단 목록 조회
+### 8-3. 결제 수단 목록 조회
 
 ```
 GET /api/payment-methods
@@ -1341,7 +1341,7 @@ GET /api/payment-methods
 
 ---
 
-### 8-3. 결제 수단 삭제
+### 8-4. 결제 수단 삭제
 
 ```
 DELETE /api/payment-methods/{methodId}
@@ -1371,7 +1371,7 @@ DELETE /api/payment-methods/{methodId}
 
 ---
 
-### 8-4. 기본 결제 수단 변경
+### 8-5. 기본 결제 수단 변경
 
 ```
 PATCH /api/payment-methods/{methodId}/default

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -120,7 +120,7 @@ public abstract class CustomException extends RuntimeException {
 
 ```yaml
 # application-local.yml 기준
-MySQL: localhost:3306/key_feed_identity (username: root, password: 1111)
+MySQL: localhost:3306/test (username: root, password: 1111)
 JWT 만료: 14일 (로컬은 길게 설정됨)
 SQL 로깅: P6Spy (p6spy: info 레벨)
 ```

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/exception/FolderLimitExceededException.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/exception/FolderLimitExceededException.java
@@ -8,4 +8,8 @@ public class FolderLimitExceededException extends CustomException {
     public FolderLimitExceededException() {
         super(ErrorMessage.BOOKMARK_FOLDER_LIMIT_EXCEEDED.getMessage(), HttpStatus.BAD_REQUEST);
     }
+
+    public FolderLimitExceededException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImpl.java
@@ -15,6 +15,8 @@ import com.keyfeed.keyfeedmonolithic.domain.bookmark.repository.BookmarkReposito
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.service.BookmarkService;
 import com.keyfeed.keyfeedmonolithic.domain.content.dto.ContentFeedResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.content.repository.ContentRepository;
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
+import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityAlreadyExistsException;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundException;
 import com.keyfeed.keyfeedmonolithic.global.response.CursorPage;
@@ -40,9 +42,13 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final BookmarkFolderRepository folderRepository;
     private final UserRepository userRepository;
     private final ContentRepository contentRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     @Value("${app.limits.folder-max-count}")
     private int folderMaxCount;
+
+    @Value("${app.limits.folder-subscriber-max-count}")
+    private int folderSubscriberMaxCount;
 
     /**
      * 폴더 생성
@@ -211,9 +217,16 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     // 북마크 폴더 최대 개수를 넘지 않는지 검증
     private void validateFolderCountLimit(Long userId) {
-        if (folderRepository.countByUserId(userId) >= folderMaxCount) {
+        int limit = hasFolderBenefit(userId) ? folderSubscriberMaxCount : folderMaxCount;
+        if (folderRepository.countByUserId(userId) >= limit) {
             throw new FolderLimitExceededException();
         }
+    }
+
+    // 구독 혜택(폴더 한도 확대) 보유 여부 확인
+    private boolean hasFolderBenefit(Long userId) {
+        return subscriptionRepository.existsByUserIdAndStatusIn(
+                userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED));
     }
 
     // 북마크가 이미 존재하는지 검증

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImpl.java
@@ -11,6 +11,7 @@ import com.keyfeed.keyfeedmonolithic.domain.bookmark.entity.BookmarkFolder;
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.exception.FolderAccessDeniedException;
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.exception.FolderLimitExceededException;
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.repository.BookmarkFolderRepository;
+import com.keyfeed.keyfeedmonolithic.global.message.ErrorMessage;
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.repository.BookmarkRepository;
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.service.BookmarkService;
 import com.keyfeed.keyfeedmonolithic.domain.content.dto.ContentFeedResponseDto;
@@ -218,14 +219,17 @@ public class BookmarkServiceImpl implements BookmarkService {
     // 북마크 폴더 최대 개수를 넘지 않는지 검증
     private void validateFolderCountLimit(Long userId) {
         int limit;
+        ErrorMessage errorMessage;
         if (hasFolderBenefit(userId)) {
             limit = folderSubscriberMaxCount;
+            errorMessage = ErrorMessage.BOOKMARK_FOLDER_SUBSCRIBER_LIMIT_EXCEEDED;
         } else {
             limit = folderMaxCount;
+            errorMessage = ErrorMessage.BOOKMARK_FOLDER_LIMIT_EXCEEDED;
         }
 
         if (folderRepository.countByUserId(userId) >= limit) {
-            throw new FolderLimitExceededException();
+            throw new FolderLimitExceededException(errorMessage);
         }
     }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImpl.java
@@ -217,7 +217,13 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     // 북마크 폴더 최대 개수를 넘지 않는지 검증
     private void validateFolderCountLimit(Long userId) {
-        int limit = hasFolderBenefit(userId) ? folderSubscriberMaxCount : folderMaxCount;
+        int limit;
+        if (hasFolderBenefit(userId)) {
+            limit = folderSubscriberMaxCount;
+        } else {
+            limit = folderMaxCount;
+        }
+
         if (folderRepository.countByUserId(userId) >= limit) {
             throw new FolderLimitExceededException();
         }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/exception/KeywordLimitExceededException.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/exception/KeywordLimitExceededException.java
@@ -10,4 +10,8 @@ public class KeywordLimitExceededException extends CustomException {
         super(ErrorMessage.KEYWORD_LIMIT_EXCEEDED.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
+    public KeywordLimitExceededException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -36,6 +36,9 @@ public class KeywordServiceImpl implements KeywordService {
     @Value("${app.limits.keyword-max-count}")
     private int keywordMaxCount;
 
+    @Value("${app.limits.keyword-subscriber-max-count}")
+    private int keywordSubscriberMaxCount;
+
     @Override
     @Transactional(readOnly = true)
     public List<KeywordResponseDto> getKeywords(Long userId) {
@@ -54,7 +57,14 @@ public class KeywordServiceImpl implements KeywordService {
             throw new EntityAlreadyExistsException("Keyword", name);
         }
 
-        if (!hasKeywordBenefit(userId) && keywordRepository.countByUserId(userId) >= keywordMaxCount) {
+        int limit;
+        if (hasKeywordBenefit(userId)) {
+            limit = keywordSubscriberMaxCount;
+        } else {
+            limit = keywordMaxCount;
+        }
+
+        if (keywordRepository.countByUserId(userId) >= limit) {
             throw new KeywordLimitExceededException();
         }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -12,6 +12,7 @@ import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
 import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityAlreadyExistsException;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundException;
+import com.keyfeed.keyfeedmonolithic.global.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -58,14 +59,17 @@ public class KeywordServiceImpl implements KeywordService {
         }
 
         int limit;
+        ErrorMessage errorMessage;
         if (hasKeywordBenefit(userId)) {
             limit = keywordSubscriberMaxCount;
+            errorMessage = ErrorMessage.KEYWORD_SUBSCRIBER_LIMIT_EXCEEDED;
         } else {
             limit = keywordMaxCount;
+            errorMessage = ErrorMessage.KEYWORD_LIMIT_EXCEEDED;
         }
 
         if (keywordRepository.countByUserId(userId) >= limit) {
-            throw new KeywordLimitExceededException();
+            throw new KeywordLimitExceededException(errorMessage);
         }
 
         Keyword keyword = Keyword.builder()

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
@@ -41,7 +41,7 @@ public enum ErrorMessage {
     RSS_PARSING_FAILED("RSS 피드를 파싱할 수 없습니다. URL을 확인해주세요."),
 
     // bookmark
-    BOOKMARK_FOLDER_LIMIT_EXCEEDED("북마크 폴더 생성 한도를 넘었습니다."),
+    BOOKMARK_FOLDER_LIMIT_EXCEEDED("북마크 폴더 생성 한도를 넘었습니다. 구독 시 최대 20개까지 이용하실 수 있습니다."),
 
     // payment
     INVALID_PAYMENT_METHOD("유효하지 않은 결제 수단입니다."),

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
@@ -33,6 +33,7 @@ public enum ErrorMessage {
 
     // keyword
     KEYWORD_LIMIT_EXCEEDED("키워드 등록 한도를 넘었습니다. 구독 시 최대 10개까지 이용하실 수 있습니다."),
+    KEYWORD_SUBSCRIBER_LIMIT_EXCEEDED("키워드 등록 한도(10개)에 도달했습니다."),
 
     // crawl
     INVALID_RSS_URL("해당 URL에 접근할 수 없거나 유효한 웹사이트가 아닙니다."),
@@ -42,6 +43,7 @@ public enum ErrorMessage {
 
     // bookmark
     BOOKMARK_FOLDER_LIMIT_EXCEEDED("북마크 폴더 생성 한도를 넘었습니다. 구독 시 최대 20개까지 이용하실 수 있습니다."),
+    BOOKMARK_FOLDER_SUBSCRIBER_LIMIT_EXCEEDED("북마크 폴더 생성 한도(20개)에 도달했습니다."),
 
     // payment
     INVALID_PAYMENT_METHOD("유효하지 않은 결제 수단입니다."),

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/message/ErrorMessage.java
@@ -32,7 +32,7 @@ public enum ErrorMessage {
     EMAIL_ALREADY_VERIFIED("이미 인증된 이메일입니다."),
 
     // keyword
-    KEYWORD_LIMIT_EXCEEDED("키워드 등록 한도를 넘었습니다. 구독 시 무제한으로 이용하실 수 있습니다."),
+    KEYWORD_LIMIT_EXCEEDED("키워드 등록 한도를 넘었습니다. 구독 시 최대 10개까지 이용하실 수 있습니다."),
 
     // crawl
     INVALID_RSS_URL("해당 URL에 접근할 수 없거나 유효한 웹사이트가 아닙니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -46,7 +46,8 @@ jwt:
 app:
   limits:
     keyword-max-count: 3
-    folder-max-count: 7
+    folder-max-count: 3
+    folder-subscriber-max-count: 20
 
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -46,6 +46,7 @@ jwt:
 app:
   limits:
     keyword-max-count: 3
+    keyword-subscriber-max-count: 10
     folder-max-count: 3
     folder-subscriber-max-count: 20
 

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImplTest.java
@@ -194,7 +194,7 @@ class BookmarkServiceImplTest {
     }
 
     @Test
-    @DisplayName("구독자(ACTIVE) - 구독자 한도(20개)에 도달하면 FolderLimitExceededException 발생")
+    @DisplayName("구독자(ACTIVE) - 구독자 한도(20개)에 도달하면 구독자용 메시지로 예외 발생")
     void 구독자_한도_도달_예외_발생() {
         // given
         Long userId = 6L;
@@ -208,7 +208,8 @@ class BookmarkServiceImplTest {
 
         // when & then
         assertThatThrownBy(() -> bookmarkService.createFolder(userId, request))
-                .isInstanceOf(FolderLimitExceededException.class);
+                .isInstanceOf(FolderLimitExceededException.class)
+                .hasMessageContaining("북마크 폴더 생성 한도(20개)에 도달했습니다");
 
         then(folderRepository).should(never()).save(any(BookmarkFolder.class));
     }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/bookmark/service/impl/BookmarkServiceImplTest.java
@@ -1,0 +1,294 @@
+package com.keyfeed.keyfeedmonolithic.domain.bookmark.service.impl;
+
+import com.keyfeed.keyfeedmonolithic.domain.auth.entity.User;
+import com.keyfeed.keyfeedmonolithic.domain.auth.repository.UserRepository;
+import com.keyfeed.keyfeedmonolithic.domain.bookmark.dto.BookmarkFolderRequestDto;
+import com.keyfeed.keyfeedmonolithic.domain.bookmark.entity.BookmarkFolder;
+import com.keyfeed.keyfeedmonolithic.domain.bookmark.exception.FolderLimitExceededException;
+import com.keyfeed.keyfeedmonolithic.domain.bookmark.repository.BookmarkFolderRepository;
+import com.keyfeed.keyfeedmonolithic.domain.bookmark.repository.BookmarkRepository;
+import com.keyfeed.keyfeedmonolithic.domain.content.repository.ContentRepository;
+import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
+import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
+import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityAlreadyExistsException;
+import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkServiceImplTest {
+
+    @InjectMocks
+    private BookmarkServiceImpl bookmarkService;
+
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+
+    @Mock
+    private BookmarkFolderRepository folderRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ContentRepository contentRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    private static final int FOLDER_MAX_COUNT = 3;
+    private static final int FOLDER_SUBSCRIBER_MAX_COUNT = 20;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(bookmarkService, "folderMaxCount", FOLDER_MAX_COUNT);
+        ReflectionTestUtils.setField(bookmarkService, "folderSubscriberMaxCount", FOLDER_SUBSCRIBER_MAX_COUNT);
+    }
+
+    private User makeUser(Long id) {
+        return User.builder()
+                .email("test@test.com")
+                .username("testUser")
+                .build();
+    }
+
+    private BookmarkFolderRequestDto makeRequest(String name) {
+        return BookmarkFolderRequestDto.builder()
+                .name(name)
+                .icon("📁")
+                .color("#FFFFFF")
+                .build();
+    }
+
+    private BookmarkFolder makeFolder(User user, String name) {
+        return BookmarkFolder.builder()
+                .user(user)
+                .name(name)
+                .icon("📁")
+                .color("#FFFFFF")
+                .build();
+    }
+
+    @Test
+    @DisplayName("비구독자 - 한도 미만이면 폴더 생성 성공")
+    void 비구독자_한도_미만_폴더_생성_성공() {
+        // given
+        Long userId = 1L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("개발");
+        BookmarkFolder folder = makeFolder(user, "개발");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "개발")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
+        given(folderRepository.countByUserId(userId)).willReturn(2L);
+        given(folderRepository.save(any(BookmarkFolder.class))).willReturn(folder);
+
+        // when
+        bookmarkService.createFolder(userId, request);
+
+        // then
+        then(folderRepository).should(times(1)).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("비구독자 - 한도(3개)에 도달하면 FolderLimitExceededException 발생")
+    void 비구독자_한도_도달_예외_발생() {
+        // given
+        Long userId = 2L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("알고리즘");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "알고리즘")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
+        given(folderRepository.countByUserId(userId)).willReturn((long) FOLDER_MAX_COUNT);
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.createFolder(userId, request))
+                .isInstanceOf(FolderLimitExceededException.class)
+                .hasMessageContaining("구독 시 최대 20개까지 이용하실 수 있습니다");
+
+        then(folderRepository).should(never()).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("비구독자 - 한도(3개) 초과 시 FolderLimitExceededException 발생")
+    void 비구독자_한도_초과_예외_발생() {
+        // given
+        Long userId = 3L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("스터디");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "스터디")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
+        given(folderRepository.countByUserId(userId)).willReturn(5L);
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.createFolder(userId, request))
+                .isInstanceOf(FolderLimitExceededException.class);
+
+        then(folderRepository).should(never()).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("비구독자 - 한도보다 1개 적을 때 폴더 생성 성공")
+    void 비구독자_한도보다_1개_적을때_성공() {
+        // given
+        Long userId = 4L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("독서");
+        BookmarkFolder folder = makeFolder(user, "독서");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "독서")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
+        given(folderRepository.countByUserId(userId)).willReturn((long) FOLDER_MAX_COUNT - 1);
+        given(folderRepository.save(any(BookmarkFolder.class))).willReturn(folder);
+
+        // when
+        bookmarkService.createFolder(userId, request);
+
+        // then
+        then(folderRepository).should(times(1)).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("구독자(ACTIVE) - 비구독 한도(3개) 초과해도 폴더 생성 성공")
+    void 구독자_비구독_한도_초과해도_폴더_생성_성공() {
+        // given
+        Long userId = 5L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("프로젝트");
+        BookmarkFolder folder = makeFolder(user, "프로젝트");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "프로젝트")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(folderRepository.countByUserId(userId)).willReturn(10L);
+        given(folderRepository.save(any(BookmarkFolder.class))).willReturn(folder);
+
+        // when
+        bookmarkService.createFolder(userId, request);
+
+        // then
+        then(folderRepository).should(times(1)).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("구독자(ACTIVE) - 구독자 한도(20개)에 도달하면 FolderLimitExceededException 발생")
+    void 구독자_한도_도달_예외_발생() {
+        // given
+        Long userId = 6L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("사이드프로젝트");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "사이드프로젝트")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(folderRepository.countByUserId(userId)).willReturn((long) FOLDER_SUBSCRIBER_MAX_COUNT);
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.createFolder(userId, request))
+                .isInstanceOf(FolderLimitExceededException.class);
+
+        then(folderRepository).should(never()).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("구독자(ACTIVE) - 구독자 한도(20개) 미만이면 폴더 생성 성공")
+    void 구독자_한도_미만_폴더_생성_성공() {
+        // given
+        Long userId = 7L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("취미");
+        BookmarkFolder folder = makeFolder(user, "취미");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "취미")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(folderRepository.countByUserId(userId)).willReturn(19L);
+        given(folderRepository.save(any(BookmarkFolder.class))).willReturn(folder);
+
+        // when
+        bookmarkService.createFolder(userId, request);
+
+        // then
+        then(folderRepository).should(times(1)).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("구독자(CANCELED, 만료 전) - 구독 한도 내에서 폴더 생성 성공")
+    void 구독취소_만료전_한도_내_폴더_생성_성공() {
+        // given
+        Long userId = 8L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("아이디어");
+        BookmarkFolder folder = makeFolder(user, "아이디어");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "아이디어")).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(folderRepository.countByUserId(userId)).willReturn(5L);
+        given(folderRepository.save(any(BookmarkFolder.class))).willReturn(folder);
+
+        // when
+        bookmarkService.createFolder(userId, request);
+
+        // then
+        then(folderRepository).should(times(1)).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("중복 폴더 이름으로 생성 시 EntityAlreadyExistsException 발생")
+    void 중복_폴더명_예외_발생() {
+        // given
+        Long userId = 9L;
+        User user = makeUser(userId);
+        BookmarkFolderRequestDto request = makeRequest("중복폴더");
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(folderRepository.existsByUserIdAndName(userId, "중복폴더")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.createFolder(userId, request))
+                .isInstanceOf(EntityAlreadyExistsException.class);
+
+        then(subscriptionRepository).should(never()).existsByUserIdAndStatusIn(any(), any());
+        then(folderRepository).should(never()).save(any(BookmarkFolder.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 폴더 생성 시 EntityNotFoundException 발생")
+    void 존재하지_않는_사용자_예외_발생() {
+        // given
+        Long userId = 999L;
+        BookmarkFolderRequestDto request = makeRequest("테스트폴더");
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.createFolder(userId, request))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        then(folderRepository).should(never()).save(any(BookmarkFolder.class));
+    }
+}

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
@@ -46,10 +46,12 @@ class KeywordServiceImplTest {
     private SubscriptionRepository subscriptionRepository;
 
     private static final int KEYWORD_MAX_COUNT = 3;
+    private static final int KEYWORD_SUBSCRIBER_MAX_COUNT = 10;
 
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(keywordService, "keywordMaxCount", KEYWORD_MAX_COUNT);
+        ReflectionTestUtils.setField(keywordService, "keywordSubscriberMaxCount", KEYWORD_SUBSCRIBER_MAX_COUNT);
     }
 
     private User makeUser(Long id) {
@@ -65,6 +67,8 @@ class KeywordServiceImplTest {
                 .name(name)
                 .build();
     }
+
+    // ── 비구독자 ──────────────────────────────────────────────────────
 
     @Test
     @DisplayName("비구독자 - 한도 미만이면 키워드 추가 성공")
@@ -90,31 +94,75 @@ class KeywordServiceImplTest {
     }
 
     @Test
+    @DisplayName("비구독자 - 한도보다 1개 적을 때 키워드 추가 성공")
+    void 비구독자_한도보다_1개_적을때_성공() {
+        // given
+        Long userId = 2L;
+        String keywordName = "도커";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
+        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT - 1);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+
+        // then
+        assertThat(result.getName()).isEqualTo(keywordName);
+    }
+
+    @Test
+    @DisplayName("비구독자 - 정확히 한도(3개)에 도달하면 KeywordLimitExceededException 발생")
+    void 비구독자_정확히_한도_도달_예외_발생() {
+        // given
+        Long userId = 3L;
+        String keywordName = "파이썬";
+        User user = makeUser(userId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
+        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT);
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
+                .isInstanceOf(KeywordLimitExceededException.class)
+                .hasMessageContaining("최대 10개까지 이용하실 수 있습니다");
+
+        then(keywordRepository).should(never()).save(any(Keyword.class));
+    }
+
+    @Test
     @DisplayName("비구독자 - 한도(3개) 초과 시 KeywordLimitExceededException 발생")
     void 비구독자_한도_초과_예외_발생() {
         // given
-        Long userId = 2L;
+        Long userId = 4L;
         String keywordName = "자바";
         User user = makeUser(userId);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
         given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
-        given(keywordRepository.countByUserId(userId)).willReturn(3L);
+        given(keywordRepository.countByUserId(userId)).willReturn(5L);
 
         // when & then
         assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
-                .isInstanceOf(KeywordLimitExceededException.class)
-                .hasMessageContaining("구독 시 무제한으로 이용하실 수 있습니다");
+                .isInstanceOf(KeywordLimitExceededException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
     }
 
+    // ── 구독자(ACTIVE) ─────────────────────────────────────────────────
+
     @Test
-    @DisplayName("구독자(ACTIVE) - 한도 초과해도 키워드 추가 성공")
-    void 구독자_한도_초과해도_키워드_추가_성공() {
+    @DisplayName("구독자(ACTIVE) - 비구독 한도(3개) 초과해도 구독자 한도 내이면 키워드 추가 성공")
+    void 구독자_비구독_한도_초과해도_구독자_한도_내_추가_성공() {
         // given
-        Long userId = 3L;
+        Long userId = 5L;
         String keywordName = "코틀린";
         User user = makeUser(userId);
         Keyword keyword = makeKeyword(1L, user, keywordName);
@@ -122,6 +170,7 @@ class KeywordServiceImplTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
         given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(keywordRepository.countByUserId(userId)).willReturn(9L);
         given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
 
         // when
@@ -129,37 +178,34 @@ class KeywordServiceImplTest {
 
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
-        then(keywordRepository).should(never()).countByUserId(userId);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
     }
 
     @Test
-    @DisplayName("구독자(ACTIVE) - 한도(100개)를 크게 초과해도 키워드 추가 성공")
-    void 구독자_대량_키워드_추가_성공() {
+    @DisplayName("구독자(ACTIVE) - 구독자 한도(10개)에 도달하면 KeywordLimitExceededException 발생")
+    void 구독자_한도_도달_예외_발생() {
         // given
-        Long userId = 4L;
+        Long userId = 6L;
         String keywordName = "리액트";
         User user = makeUser(userId);
-        Keyword keyword = makeKeyword(1L, user, keywordName);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
         given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
-        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_SUBSCRIBER_MAX_COUNT);
 
-        // when
-        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+        // when & then
+        assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
+                .isInstanceOf(KeywordLimitExceededException.class);
 
-        // then
-        assertThat(result).isNotNull();
-        then(keywordRepository).should(never()).countByUserId(any());
+        then(keywordRepository).should(never()).save(any(Keyword.class));
     }
 
     @Test
-    @DisplayName("구독자(CANCELED, 만료 전) - 한도 초과해도 키워드 추가 성공")
-    void 구독_취소_만료전_한도_초과해도_키워드_추가_성공() {
+    @DisplayName("구독자(ACTIVE) - 구독자 한도(10개) 미만이면 키워드 추가 성공")
+    void 구독자_한도_미만_키워드_추가_성공() {
         // given
-        Long userId = 8L;
+        Long userId = 7L;
         String keywordName = "쿠버네티스";
         User user = makeUser(userId);
         Keyword keyword = makeKeyword(1L, user, keywordName);
@@ -167,6 +213,7 @@ class KeywordServiceImplTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
         given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_SUBSCRIBER_MAX_COUNT - 1);
         given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
 
         // when
@@ -174,15 +221,61 @@ class KeywordServiceImplTest {
 
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
-        then(keywordRepository).should(never()).countByUserId(userId);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
     }
+
+    // ── 구독자(CANCELED, 만료 전) ─────────────────────────────────────
+
+    @Test
+    @DisplayName("구독자(CANCELED, 만료 전) - 구독자 한도 내이면 키워드 추가 성공")
+    void 구독취소_만료전_한도_내_키워드_추가_성공() {
+        // given
+        Long userId = 8L;
+        String keywordName = "그래들";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(keywordRepository.countByUserId(userId)).willReturn(5L);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
+
+        // then
+        assertThat(result.getName()).isEqualTo(keywordName);
+        then(keywordRepository).should(times(1)).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("구독자(CANCELED, 만료 전) - 구독자 한도(10개) 초과 시 KeywordLimitExceededException 발생")
+    void 구독취소_만료전_한도_초과_예외_발생() {
+        // given
+        Long userId = 9L;
+        String keywordName = "넥스트";
+        User user = makeUser(userId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(true);
+        given(keywordRepository.countByUserId(userId)).willReturn(10L);
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
+                .isInstanceOf(KeywordLimitExceededException.class);
+
+        then(keywordRepository).should(never()).save(any(Keyword.class));
+    }
+
+    // ── 공통 예외 ──────────────────────────────────────────────────────
 
     @Test
     @DisplayName("중복 키워드 등록 시 EntityAlreadyExistsException 발생")
     void 중복_키워드_등록_예외_발생() {
         // given
-        Long userId = 5L;
+        Long userId = 10L;
         String keywordName = "중복키워드";
         User user = makeUser(userId);
 
@@ -210,45 +303,5 @@ class KeywordServiceImplTest {
                 .isInstanceOf(EntityNotFoundException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
-    }
-
-    @Test
-    @DisplayName("비구독자 - 정확히 한도(3개)와 동일한 경우 예외 발생")
-    void 비구독자_정확히_한도_동일_예외_발생() {
-        // given
-        Long userId = 6L;
-        String keywordName = "파이썬";
-        User user = makeUser(userId);
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
-        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT);
-
-        // when & then
-        assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
-                .isInstanceOf(KeywordLimitExceededException.class);
-    }
-
-    @Test
-    @DisplayName("비구독자 - 한도보다 1개 적을 때 키워드 추가 성공")
-    void 비구독자_한도보다_1개_적을때_성공() {
-        // given
-        Long userId = 7L;
-        String keywordName = "도커";
-        User user = makeUser(userId);
-        Keyword keyword = makeKeyword(1L, user, keywordName);
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
-        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
-        given(keywordRepository.countByUserId(userId)).willReturn((long) KEYWORD_MAX_COUNT - 1);
-        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
-
-        // when
-        KeywordResponseDto result = keywordService.addKeyword(userId, keywordName);
-
-        // then
-        assertThat(result.getName()).isEqualTo(keywordName);
     }
 }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
@@ -182,7 +182,7 @@ class KeywordServiceImplTest {
     }
 
     @Test
-    @DisplayName("구독자(ACTIVE) - 구독자 한도(10개)에 도달하면 KeywordLimitExceededException 발생")
+    @DisplayName("구독자(ACTIVE) - 구독자 한도(10개)에 도달하면 구독자용 메시지로 예외 발생")
     void 구독자_한도_도달_예외_발생() {
         // given
         Long userId = 6L;
@@ -196,7 +196,8 @@ class KeywordServiceImplTest {
 
         // when & then
         assertThatThrownBy(() -> keywordService.addKeyword(userId, keywordName))
-                .isInstanceOf(KeywordLimitExceededException.class);
+                .isInstanceOf(KeywordLimitExceededException.class)
+                .hasMessageContaining("키워드 등록 한도(10개)에 도달했습니다");
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
     }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -41,6 +41,7 @@ jasypt:
 
 app:
   limits:
-    keyword-max-count: 20
+    keyword-max-count: 3
+    keyword-subscriber-max-count: 10
     folder-max-count: 3
     folder-subscriber-max-count: 20

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -42,4 +42,5 @@ jasypt:
 app:
   limits:
     keyword-max-count: 20
-    folder-max-count: 7
+    folder-max-count: 3
+    folder-subscriber-max-count: 20


### PR DESCRIPTION
## 개요
구독 여부에 따라 키워드 및 북마크 폴더 생성 한도를 차등 적용합니다.

## 변경 사항

### 북마크 폴더 한도 (#48)
| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| 비구독자 | 7개 | 3개 |
| 구독자 | 7개 | 20개 |

### 키워드 한도
| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| 비구독자 | 3개 | 3개 (유지) |
| 구독자 | 무제한 | 10개 |

### 한도 초과 에러 메시지 분기
| 구분 | 메시지 |
|------|--------|
| 비구독자 | "...구독 시 최대 N개까지 이용하실 수 있습니다." |
| 구독자 | "...한도(N개)에 도달했습니다." |

## 주요 변경 파일
- `BookmarkServiceImpl` - `SubscriptionRepository` 주입, 구독 여부 분기 처리
- `KeywordServiceImpl` - 구독자 한도(10개) 적용
- `FolderLimitExceededException` / `KeywordLimitExceededException` - `ErrorMessage` 수신 생성자 추가
- `application.yml` - `folder-max-count: 3`, `folder-subscriber-max-count: 20`, `keyword-subscriber-max-count: 10` 추가
- `ErrorMessage` - 구독자용 한도 도달 메시지 추가

## 테스트
- `BookmarkServiceImplTest` - 폴더 한도 단위 테스트 10개 신규 작성
- `KeywordServiceImplTest` - 구독자 한도 기준으로 테스트 전면 수정 (총 11개)

## 문서 수정
- `CLAUDE.md`: 로컬 DB명 오류 수정 (`key_feed_identity` → `test`)
- `API_SPEC.md`: 결제 수단 섹션 번호 중복(8-2) 수정 (8-3~8-5로 재정렬)