### PR TITLE
[CHORE] 무중단 배포를 위한 Nginx blue-green 설정 추가

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,9 @@ RUN npm run build
 # ---- Runtime Stage ----
 FROM nginx:stable-alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx/service-url.inc /etc/nginx/conf.d/service-url.inc
 
 EXPOSE 80
 

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # 동적 backend URL 주입을 위한 include
+    include /etc/nginx/conf.d/service-url.inc;
+
     location / {
         try_files $uri $uri/ /index.html;
     }
@@ -11,8 +14,7 @@ server {
     location /api/ {
         # Nginx 시작 시 백엔드 컨테이너가 없더라도 크래시 나지 않게 동적 DNS 확인 (Docker 내부 DNS 활용)
         resolver 127.0.0.11 valid=30s;
-        set $backend "http://keyfeed-backend:8080";
-        proxy_pass $backend;
+        proxy_pass $service_url;
 
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/frontend/nginx/service-url.inc
+++ b/frontend/nginx/service-url.inc
@@ -1,0 +1,1 @@
+set $service_url http://app-blue:8080;


### PR DESCRIPTION
## Summary
- `nginx/nginx.conf`: Nginx 설정을 `nginx/` 디렉토리로 이동 및 `service-url.inc` include 적용
- `nginx/service-url.inc`: blue-green 배포 시 동적으로 교체될 서비스 URL 설정 파일 추가
- `Dockerfile`: `nginx/` 디렉토리의 설정 파일 및 `service-url.inc` 복사하도록 수정
- `deploy.yml`: `workflow_dispatch`에 백엔드/프론트엔드 배포 선택 입력 추가

## 수동 배포 방법

코드 변경 없이 배포가 필요할 때 GitHub Actions에서 직접 워크플로우를 실행할 수 있습니다.

### 1. Actions 탭으로 이동

`GitHub 레포지토리 → Actions → CI/CD Deploy`

### 2. Run workflow 클릭

우측 상단의 **Run workflow** 버튼을 클릭합니다.

### 3. 배포 대상 선택 후 실행

| 입력 | 기본값 | 설명 |
|---|---|---|
| `deploy_backend` | ✅ true | 백엔드 배포 여부 |
| `deploy_frontend` | ☐ false | 프론트엔드 배포 여부 |

- **백엔드만 배포**: 기본값 그대로 실행
- **프론트엔드만 배포**: `deploy_backend` 해제 후 `deploy_frontend` 체크
- **둘 다 배포**: 두 항목 모두 체크

## Test plan
- [ ] Dockerfile 빌드 정상 여부 확인
- [ ] Nginx가 `service-url.inc`를 정상 include하는지 확인
- [ ] `/api/` 프록시가 `$service_url` 변수로 정상 동작하는지 확인
- [ ] `workflow_dispatch` 수동 실행 시 백엔드 배포 job이 정상 트리거되는지 확인