### PR TITLE
[CHORE] 무중단 배포를 위한 Nginx blue-green 설정 및 수동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,15 @@ on:
       - 'backend/**'
       - 'frontend/**'
   workflow_dispatch:
+    inputs:
+      deploy_backend:
+        description: '백엔드 배포'
+        type: boolean
+        default: true
+      deploy_frontend:
+        description: '프론트엔드 배포'
+        type: boolean
+        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -41,7 +50,9 @@ jobs:
   deploy-backend:
     name: Deploy Backend
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend == 'true'
+    if: >
+      needs.detect-changes.outputs.backend == 'true' ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_backend == true)
     runs-on: ubuntu-latest
 
     steps:
@@ -102,7 +113,9 @@ jobs:
   deploy-frontend:
     name: Deploy Frontend
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend == 'true'
+    if: >
+      needs.detect-changes.outputs.frontend == 'true' ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_frontend == true)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- `frontend/nginx/nginx.conf`: Nginx 설정을 `nginx/` 디렉토리로 이동 및 `service-url.inc` include 적용
- `frontend/nginx/service-url.inc`: blue-green 배포 시 동적으로 교체될 서비스 URL 설정 파일 추가
- `frontend/Dockerfile`: `nginx/` 디렉토리의 설정 파일 및 `service-url.inc` 복사하도록 수정
- `.github/workflows/deploy.yml`: `workflow_dispatch`에 백엔드/프론트엔드 배포 선택 입력 추가

## 수동 배포 방법

코드 변경 없이 배포가 필요할 때 GitHub Actions에서 직접 워크플로우를 실행할 수 있습니다.

### 1. Actions 탭으로 이동

`GitHub 레포지토리 → Actions → CI/CD Deploy`

### 2. Run workflow 클릭

우측 상단의 **Run workflow** 버튼을 클릭합니다.

### 3. 배포 대상 선택 후 실행

| 입력 | 기본값 | 설명 |
|---|---|---|
| `deploy_backend` | ✅ true | 백엔드 배포 여부 |
| `deploy_frontend` | ☐ false | 프론트엔드 배포 여부 |

- **백엔드만 배포**: 기본값 그대로 실행
- **프론트엔드만 배포**: `deploy_backend` 해제 후 `deploy_frontend` 체크
- **둘 다 배포**: 두 항목 모두 체크

## Test plan
- [ ] Dockerfile 빌드 정상 여부 확인
- [ ] Nginx가 `service-url.inc`를 정상 include하는지 확인
- [ ] `/api/` 프록시가 `$service_url` 변수로 정상 동작하는지 확인
- [ ] `workflow_dispatch` 수동 실행 시 선택한 배포 job이 정상 트리거되는지 확인