### PR TITLE
[REFACTOR(frontend)] 피드 읽음 처리 제거 및 구독 UI 개선

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,10 +3,10 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta name="viewport"
     content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-  <title>Key Feed - Mobile Experience</title>
+  <title>Key Feed</title>
   <!-- SEO Meta Tags -->
   <meta name="description" content="A beautiful and dynamic mobile feed experience built with React and Vite." />
   <meta name="theme-color" content="#121212" />

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <!-- Rounded white square with a subtle drop shadow (simulating the shadow-sm/xl) -->
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0f172a" flood-opacity="0.1" />
+    </filter>
+  </defs>
+  <rect width="108" height="108" x="10" y="10" rx="24" fill="#ffffff" filter="url(#shadow)" />
+  
+  <!-- Terminal Lucide Icon in Indigo-600 (#4f46e5) -->
+  <!-- The original lucide icon is 24x24. Scaling it up to fit in the 128x128 canvas -->
+  <!-- Target size: ~64x64, which is 2.66x scale. Let's use scale(2.66) -->
+  <g transform="translate(32, 32) scale(2.666)">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#4f46e5" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <polyline points="4 17 10 11 4 5"/>
+      <line x1="12" x2="20" y1="19" y2="19"/>
+    </svg>
+  </g>
+</svg>

--- a/frontend/src/features/feed/components/PostCard.tsx
+++ b/frontend/src/features/feed/components/PostCard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Bookmark, FolderOpen } from 'lucide-react';
 import type { Post } from '@/types';
-import { usePostStore } from '@/stores/postStore';
 import { useCreateBookmark, useDeleteBookmark } from '@/features/saved/api/bookmarkApi';
 import { useQueryClient } from '@tanstack/react-query';
 import { FolderChangeOverlay } from './FolderChangeOverlay';
@@ -12,9 +11,6 @@ interface PostCardProps {
 }
 
 export function PostCard({ post, onClick }: PostCardProps) {
-    const { readPostIds } = usePostStore();
-    const isRead = readPostIds.includes(post.id);
-
     const queryClient = useQueryClient();
     const createBookmark = useCreateBookmark();
     const deleteBookmark = useDeleteBookmark();
@@ -56,7 +52,7 @@ export function PostCard({ post, onClick }: PostCardProps) {
         <div
             id={`post-${post.id}`}
             onClick={() => onClick(post)}
-            className={`bg-white/40 backdrop-blur-xl rounded-[24px] border border-white/60 p-4 shadow-sm active:scale-[0.98] transition-all cursor-pointer hover:bg-white/60 ${isRead ? 'opacity-70' : ''}`}
+            className={`bg-white/40 backdrop-blur-xl rounded-[24px] border border-white/60 p-4 shadow-sm active:scale-[0.98] transition-all cursor-pointer hover:bg-white/60`}
         >
             <div className="flex items-start gap-4">
                 <div className="flex-1">
@@ -66,14 +62,9 @@ export function PostCard({ post, onClick }: PostCardProps) {
                             <span className="text-[10px] font-black text-slate-400 uppercase tracking-tighter">
                                 {post.company}
                             </span>
-                            {isRead && (
-                                <span className="flex items-center gap-0.5 px-1 py-0.5 bg-white/40 text-slate-300 text-[8px] font-black rounded uppercase border border-white/20">
-                                    읽음
-                                </span>
-                            )}
                         </div>
                     </div>
-                    <h4 className={`text-[14px] font-bold text-slate-800 leading-snug mb-1 ${isRead ? 'text-slate-500' : ''}`}>
+                    <h4 className="text-[14px] font-bold text-slate-800 leading-snug mb-1">
                         {post.title}
                     </h4>
                     <p className="text-[11px] text-slate-500 line-clamp-1 font-medium">

--- a/frontend/src/features/feed/pages/HomeTab.tsx
+++ b/frontend/src/features/feed/pages/HomeTab.tsx
@@ -1,4 +1,3 @@
-import { usePostStore } from '@/stores/postStore';
 import { PostCard } from '@/features/feed/components/PostCard';
 import type { Post } from '@/types';
 import { useState } from 'react';
@@ -8,7 +7,6 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { Loader2 } from 'lucide-react';
 
 export function HomeTab() {
-    const { markAsRead } = usePostStore();
     const [selectedPost, setSelectedPost] = useState<Post | null>(null);
 
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } = useFeed();
@@ -20,7 +18,6 @@ export function HomeTab() {
 
     const handlePostClick = (post: Post) => {
         setSelectedPost(post);
-        markAsRead(post.id);
     };
 
     // Flatten pages to a single array of items and map to Post interface

--- a/frontend/src/features/payment/pages/PaymentMethodManageOverlay.tsx
+++ b/frontend/src/features/payment/pages/PaymentMethodManageOverlay.tsx
@@ -72,7 +72,14 @@ export function PaymentMethodManageOverlay() {
     })();
 
     const handleCancelSubscription = () => {
-        if (!confirm('구독을 해지하시겠습니까?\n만료일까지 서비스는 계속 이용 가능합니다.')) return;
+        const confirmMsg =
+            '구독을 해지하시겠습니까?\n\n' +
+            '[해지 후 처리 안내]\n' +
+            '- 키워드: 만료일 다음 자정에 초과분 비활성화 (삭제 아님, 재구독 시 복원)\n' +
+            '- 북마크 폴더: 처리 없음 (초과 폴더 그대로 유지됨)\n\n' +
+            '만료일까지 서비스는 계속 이용 가능합니다.';
+
+        if (!confirm(confirmMsg)) return;
         cancelSub(undefined, {
             onError: (err: any) => {
                 alert(err?.response?.data?.message || '구독 해지에 실패했습니다.');
@@ -81,7 +88,14 @@ export function PaymentMethodManageOverlay() {
     };
 
     const handleRefundSubscription = () => {
-        if (!confirm('구독을 즉시 취소하고 환불받으시겠습니까?')) return;
+        const confirmMsg =
+            '구독을 즉시 취소하고 환불받으시겠습니까?\n\n' +
+            '[취소 후 처리 안내]\n' +
+            '- 키워드: 즉시 초과분 비활성화 (삭제 아님, 재구독 시 복원)\n' +
+            '- 북마크 폴더: 처리 없음 (초과 폴더 그대로 유지됨)\n\n' +
+            '서비스 이용이 즉시 중단됩니다.';
+
+        if (!confirm(confirmMsg)) return;
         refundSub(undefined, {
             onError: (err: any) => {
                 alert(err?.response?.data?.message || '구독 취소에 실패했습니다.');

--- a/frontend/src/features/payment/pages/SubscriptionManageOverlay.tsx
+++ b/frontend/src/features/payment/pages/SubscriptionManageOverlay.tsx
@@ -113,7 +113,14 @@ export function SubscriptionManageOverlay() {
     }, [isSubscriptionOpen, unmountSubscriptionManage, contextSafe]);
 
     const handleRefund = async () => {
-        if (!confirm('구독을 즉시 취소하고 환불받으시겠습니까?')) return;
+        const confirmMsg =
+            '구독을 즉시 취소하고 환불받으시겠습니까?\n\n' +
+            '[취소 후 처리 안내]\n' +
+            '- 키워드: 즉시 초과분 비활성화 (삭제 아님, 재구독 시 복원)\n' +
+            '- 북마크 폴더: 처리 없음 (초과 폴더 그대로 유지됨)\n\n' +
+            '서비스 이용이 즉시 중단됩니다.';
+
+        if (!confirm(confirmMsg)) return;
         try {
             await refundAsync(undefined);
         } catch (err: any) {
@@ -122,7 +129,14 @@ export function SubscriptionManageOverlay() {
     };
 
     const handleCancel = async () => {
-        if (!confirm('구독을 해지하시겠습니까?\n만료일까지 서비스는 계속 이용 가능합니다.')) return;
+        const confirmMsg =
+            '구독을 해지하시겠습니까?\n\n' +
+            '[해지 후 처리 안내]\n' +
+            '- 키워드: 만료일 다음 자정에 초과분 비활성화 (삭제 아님, 재구독 시 복원)\n' +
+            '- 북마크 폴더: 처리 없음 (초과 폴더 그대로 유지됨)\n\n' +
+            '만료일까지 서비스는 계속 이용 가능합니다.';
+            
+        if (!confirm(confirmMsg)) return;
         try {
             await cancelAsync(undefined);
         } catch (err: any) {

--- a/frontend/src/features/profile/pages/UpgradePlanOverlay.tsx
+++ b/frontend/src/features/profile/pages/UpgradePlanOverlay.tsx
@@ -11,10 +11,8 @@ const clientKey = import.meta.env.VITE_TOSS_CLIENT_KEY || "test_ck_D5GePWvyJnrK0
 
 const FEATURES = [
     { icon: Bookmark, title: '무제한 북마크', desc: '원하는 만큼 저장하고 관리하세요' },
-    { icon: Folder, title: '무제한 폴더', desc: '폴더를 자유롭게 생성하세요' },
-    { icon: Tag, title: '무제한 키워드', desc: '관심 있는 키워드를 제한 없이 추가하세요' },
-    { icon: Star, title: '프리미엄 테마', desc: '독점 테마와 아이콘 팩 제공' },
-    { icon: Zap, title: 'AI 추천 엔진', desc: '개인화된 콘텐츠 큐레이션' }
+    { icon: Folder, title: '북마크 폴더 20개', desc: '북마크 폴더를 최대 20개까지 생성할 수 있어요' },
+    { icon: Tag, title: '관심 키워드 10개', desc: '관심 키워드를 최대 10개까지 추가할 수 있어요' }
 ];
 
 export function UpgradePlanOverlay() {
@@ -141,11 +139,6 @@ export function UpgradePlanOverlay() {
                         </div>
                         <p className="text-[10px] font-medium text-slate-400 opacity-80 mb-6">언제든지 취소 가능합니다</p>
                         <div className="flex items-center justify-center gap-4 text-[10px] font-bold text-slate-300">
-                            <div className="flex items-center gap-1.5">
-                                <CheckCircle2 size={12} className="text-emerald-400" />
-                                <span>7일 무료 체험</span>
-                            </div>
-                            <div className="w-1 h-1 rounded-full bg-slate-600"></div>
                             <div className="flex items-center gap-1.5">
                                 <CheckCircle2 size={12} className="text-emerald-400" />
                                 <span>자동 갱신</span>

--- a/frontend/src/features/saved/pages/SavedTab.tsx
+++ b/frontend/src/features/saved/pages/SavedTab.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react';
 import { Bookmark, FolderKanban, Loader2 } from 'lucide-react';
-import { usePostStore } from '@/stores/postStore';
 import { useFolderStore } from '@/stores/folderStore';
 import { useUiStore } from '@/stores/uiStore';
 import { PostCard } from '@/features/feed/components/PostCard';
@@ -32,7 +31,6 @@ function transformBookmarkToPost(item: BookmarkItem): Post {
 }
 
 export function SavedTab() {
-    const { markAsRead } = usePostStore();
     const { activeFolder, setActiveFolder } = useFolderStore();
     const { openFolderManagement } = useUiStore();
 
@@ -72,7 +70,6 @@ export function SavedTab() {
 
     const handlePostClick = (post: Post) => {
         setSelectedPost(post);
-        markAsRead(post.id);
     };
 
     return (

--- a/frontend/src/features/search/components/SearchOverlay.tsx
+++ b/frontend/src/features/search/components/SearchOverlay.tsx
@@ -3,7 +3,6 @@ import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
 import { ArrowLeft, Search, X, ChevronRight, SearchX, Loader2 } from 'lucide-react';
 import { useUiStore } from '@/stores/uiStore';
-import { usePostStore } from '@/stores/postStore';
 import { TRENDING_KEYWORDS } from '@/lib/mock';
 import type { Post } from '@/types';
 import { PostDetailOverlay } from '@/features/feed/components/PostDetailOverlay';
@@ -12,7 +11,6 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 
 export function SearchOverlay() {
     const { isSearchOpen, closeSearch, unmountSearch } = useUiStore();
-    const { markAsRead } = usePostStore();
     const overlayRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
     const { contextSafe } = useGSAP({ scope: overlayRef });
@@ -63,7 +61,6 @@ export function SearchOverlay() {
 
     const handlePostClick = (post: Post) => {
         setSelectedPost(post);
-        markAsRead(post.id);
     };
 
     const handleBack = () => {

--- a/frontend/src/stores/postStore.ts
+++ b/frontend/src/stores/postStore.ts
@@ -5,28 +5,19 @@ import { INITIAL_POSTS } from '@/lib/mock';
 interface PostState {
     posts: Post[];
     savedPostIds: (string | number)[];
-    readPostIds: (string | number)[];
 
     toggleSave: (id: string | number) => void;
-    markAsRead: (id: string | number) => void;
     setPosts: (posts: Post[]) => void;
 }
 
 export const usePostStore = create<PostState>((set) => ({
     posts: INITIAL_POSTS,
     savedPostIds: [1, 2, 3, 4], // Default mocked saved items from base.txt
-    readPostIds: [],
 
     toggleSave: (id) => set((state) => ({
         savedPostIds: state.savedPostIds.includes(id)
             ? state.savedPostIds.filter(postId => postId !== id)
             : [...state.savedPostIds, id]
-    })),
-
-    markAsRead: (id) => set((state) => ({
-        readPostIds: state.readPostIds.includes(id)
-            ? state.readPostIds
-            : [...state.readPostIds, id]
     })),
 
     setPosts: (posts) => set({ posts })


### PR DESCRIPTION
## Summary
- 피드 아이템 클릭 시 읽음 처리 기능 제거
- 프로젝트 로고 원형 파비콘 적용 및 탭 타이틀 간소화 (`Key Feed - Mobile Experience` → `Key Feed`)
- 구독 해지/취소 확인 팝업에 사후 처리 안내 메시지 상세화 (키워드 비활성화 및 북마크 폴더 유지 안내)
- Pro 업그레이드 안내 텍스트를 정확한 수치로 수정 (무제한 → 폴더 20개 / 키워드 10개), 미지원 항목 제거

## Test plan
- [ ] 파비콘이 브라우저 탭에 정상 표시되는지 확인
- [ ] 탭 타이틀이 `Key Feed`로 표시되는지 확인
- [ ] 피드 아이템 클릭 시 읽음 처리가 동작하지 않는지 확인
- [ ] 구독 해지/취소 버튼 클릭 시 안내 메시지가 포함된 확인 팝업이 표시되는지 확인
- [ ] Pro 업그레이드 오버레이에서 변경된 혜택 텍스트 확인