### PR TITLE
[FEAT] 키워드 Redis 캐시 동기화 기능 구현

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/event/KeywordCacheEvent.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/event/KeywordCacheEvent.java
@@ -1,0 +1,6 @@
+package com.keyfeed.keyfeedmonolithic.domain.keyword.event;
+
+public record KeywordCacheEvent(String keywordName, Long userId, Operation operation) {
+
+    public enum Operation { ADD, REMOVE }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/event/KeywordCacheEventListener.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/event/KeywordCacheEventListener.java
@@ -1,0 +1,21 @@
+package com.keyfeed.keyfeedmonolithic.domain.keyword.event;
+
+import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class KeywordCacheEventListener {
+
+    private final KeywordCacheRepository keywordCacheRepository;
+
+    @TransactionalEventListener
+    public void handle(KeywordCacheEvent event) {
+        switch (event.operation()) {
+            case ADD -> keywordCacheRepository.addUserToKeyword(event.keywordName(), event.userId());
+            case REMOVE -> keywordCacheRepository.removeUserFromKeyword(event.keywordName(), event.userId());
+        }
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/repository/KeywordCacheRepository.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/repository/KeywordCacheRepository.java
@@ -1,0 +1,22 @@
+package com.keyfeed.keyfeedmonolithic.domain.keyword.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class KeywordCacheRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_PREFIX = "keyword:users:";
+
+    public void addUserToKeyword(String keyword, Long userId) {
+        redisTemplate.opsForSet().add(KEY_PREFIX + keyword, String.valueOf(userId));
+    }
+
+    public void removeUserFromKeyword(String keyword, Long userId) {
+        redisTemplate.opsForSet().remove(KEY_PREFIX + keyword, (Object) String.valueOf(userId));
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/repository/KeywordRepository.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/repository/KeywordRepository.java
@@ -20,11 +20,11 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
 
     boolean existsByNameAndUser(String name, User user);
 
-    Long countByUserId(Long userId);
-
     Long countByUserIdAndIsEnabledTrue(Long userId);
 
     List<Keyword> findByUserIdOrderByCreatedAtAsc(Long userId);
+
+    List<Keyword> findByUserIdAndIsEnabledFalseAndIsNotificationEnabledTrue(Long userId);
 
     @Modifying
     @Query("UPDATE Keyword k SET k.isEnabled = true WHERE k.user.id = :userId AND k.isEnabled = false")
@@ -38,42 +38,6 @@ public interface KeywordRepository extends JpaRepository<Keyword, Long> {
             "AND k.isNotificationEnabled = true " +
             "AND k.isEnabled = true")
     List<Long> findUserIdsByNamesAndSourceId(@Param("keywords") Set<String> keywords, @Param("sourceId") Long sourceId);
-
-    @Query(value = """
-    SELECT DISTINCT k.user_id
-    FROM keyword k
-    INNER JOIN user_source us ON k.user_id = us.user_id
-    WHERE k.name IN :keywords
-    AND us.source_id = :sourceId
-    AND k.is_notification_enabled = 1
-    AND k.is_enabled = 1
-    AND us.receive_feed = 1
-    """, nativeQuery = true)
-    List<Long> findUserIdsByNamesAndSourceId(
-            @Param("keywords") Set<String> keywords,
-            @Param("sourceId") Long sourceId,
-            Pageable pageable
-    );
-
-    @Query(value = """
-    SELECT DISTINCT k.user_id
-    FROM keyword k
-    INNER JOIN user_source us ON k.user_id = us.user_id
-    WHERE k.name IN :keywords
-    AND us.source_id = :sourceId
-    AND k.is_notification_enabled = 1
-    AND k.is_enabled = 1
-    AND us.receive_feed = 1
-    AND k.user_id > :lastUserId
-    ORDER BY k.user_id ASC
-    LIMIT :chunkSize
-    """, nativeQuery = true)
-    List<Long> findUserIdsByNamesAndSourceId(
-            @Param("keywords") Set<String> keywords,
-            @Param("sourceId") Long sourceId,
-            @Param("lastUserId") Long lastUserId,
-            @Param("chunkSize") int chunkSize
-    );
 
     @Modifying
     @Query("DELETE FROM Keyword k WHERE k.user.id = :userId")

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -6,6 +6,7 @@ import com.keyfeed.keyfeedmonolithic.domain.keyword.dto.KeywordResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.dto.TrendingKeywordResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.entity.Keyword;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.exception.KeywordLimitExceededException;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordCacheRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.service.KeywordService;
 import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
@@ -33,6 +34,7 @@ public class KeywordServiceImpl implements KeywordService {
     private final KeywordRepository keywordRepository;
     private final UserRepository userRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final KeywordCacheRepository keywordCacheRepository;
 
     @Value("${app.limits.keyword-max-count}")
     private int keywordMaxCount;
@@ -78,6 +80,10 @@ public class KeywordServiceImpl implements KeywordService {
                 .build();
         keywordRepository.save(keyword);
 
+        if (keyword.isNotificationEnabled()) {
+            keywordCacheRepository.addUserToKeyword(name, userId);
+        }
+
         return KeywordResponseDto.from(keyword);
     }
 
@@ -88,6 +94,12 @@ public class KeywordServiceImpl implements KeywordService {
         keyword.setNotificationEnabled(!keyword.isNotificationEnabled());
         keywordRepository.save(keyword);
 
+        if (keyword.isNotificationEnabled()) {
+            keywordCacheRepository.addUserToKeyword(keyword.getName(), userId);
+        } else {
+            keywordCacheRepository.removeUserFromKeyword(keyword.getName(), userId);
+        }
+
         return KeywordResponseDto.from(keyword);
     }
 
@@ -96,6 +108,7 @@ public class KeywordServiceImpl implements KeywordService {
     public void deleteKeyword(Long userId, Long keywordId) {
         Keyword keyword = findKeywordByIdAndUserId(keywordId, userId);
         keywordRepository.delete(keyword);
+        keywordCacheRepository.removeUserFromKeyword(keyword.getName(), userId);
     }
 
     @Override

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -138,14 +138,22 @@ public class KeywordServiceImpl implements KeywordService {
     public void deactivateExcessKeywords(Long userId, int keepCount) {
         List<Keyword> keywords = keywordRepository.findByUserIdOrderByCreatedAtAsc(userId);
         for (int i = keepCount; i < keywords.size(); i++) {
-            keywords.get(i).disable();
+            Keyword keyword = keywords.get(i);
+            keyword.disable();
+            if (keyword.isNotificationEnabled()) {
+                keywordCacheRepository.removeUserFromKeyword(keyword.getName(), userId);
+            }
         }
     }
 
     @Override
     @Transactional
     public void reactivateAllKeywords(Long userId) {
+        List<Keyword> toReactivate =
+                keywordRepository.findByUserIdAndIsEnabledFalseAndIsNotificationEnabledTrue(userId);
         keywordRepository.enableAllByUserId(userId);
+        toReactivate.forEach(keyword ->
+                keywordCacheRepository.addUserToKeyword(keyword.getName(), userId));
     }
 
     private boolean hasKeywordBenefit(Long userId) {

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImpl.java
@@ -5,8 +5,9 @@ import com.keyfeed.keyfeedmonolithic.domain.auth.repository.UserRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.dto.KeywordResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.dto.TrendingKeywordResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.entity.Keyword;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.event.KeywordCacheEvent;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.event.KeywordCacheEvent.Operation;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.exception.KeywordLimitExceededException;
-import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordCacheRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.service.KeywordService;
 import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
@@ -17,6 +18,7 @@ import com.keyfeed.keyfeedmonolithic.global.message.ErrorMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +36,7 @@ public class KeywordServiceImpl implements KeywordService {
     private final KeywordRepository keywordRepository;
     private final UserRepository userRepository;
     private final SubscriptionRepository subscriptionRepository;
-    private final KeywordCacheRepository keywordCacheRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${app.limits.keyword-max-count}")
     private int keywordMaxCount;
@@ -81,7 +83,7 @@ public class KeywordServiceImpl implements KeywordService {
         keywordRepository.save(keyword);
 
         if (keyword.isNotificationEnabled()) {
-            keywordCacheRepository.addUserToKeyword(name, userId);
+            eventPublisher.publishEvent(new KeywordCacheEvent(name, userId, Operation.ADD));
         }
 
         return KeywordResponseDto.from(keyword);
@@ -94,11 +96,8 @@ public class KeywordServiceImpl implements KeywordService {
         keyword.setNotificationEnabled(!keyword.isNotificationEnabled());
         keywordRepository.save(keyword);
 
-        if (keyword.isNotificationEnabled()) {
-            keywordCacheRepository.addUserToKeyword(keyword.getName(), userId);
-        } else {
-            keywordCacheRepository.removeUserFromKeyword(keyword.getName(), userId);
-        }
+        Operation op = keyword.isNotificationEnabled() ? Operation.ADD : Operation.REMOVE;
+        eventPublisher.publishEvent(new KeywordCacheEvent(keyword.getName(), userId, op));
 
         return KeywordResponseDto.from(keyword);
     }
@@ -108,7 +107,7 @@ public class KeywordServiceImpl implements KeywordService {
     public void deleteKeyword(Long userId, Long keywordId) {
         Keyword keyword = findKeywordByIdAndUserId(keywordId, userId);
         keywordRepository.delete(keyword);
-        keywordCacheRepository.removeUserFromKeyword(keyword.getName(), userId);
+        eventPublisher.publishEvent(new KeywordCacheEvent(keyword.getName(), userId, Operation.REMOVE));
     }
 
     @Override
@@ -141,7 +140,7 @@ public class KeywordServiceImpl implements KeywordService {
             Keyword keyword = keywords.get(i);
             keyword.disable();
             if (keyword.isNotificationEnabled()) {
-                keywordCacheRepository.removeUserFromKeyword(keyword.getName(), userId);
+                eventPublisher.publishEvent(new KeywordCacheEvent(keyword.getName(), userId, Operation.REMOVE));
             }
         }
     }
@@ -153,7 +152,7 @@ public class KeywordServiceImpl implements KeywordService {
                 keywordRepository.findByUserIdAndIsEnabledFalseAndIsNotificationEnabledTrue(userId);
         keywordRepository.enableAllByUserId(userId);
         toReactivate.forEach(keyword ->
-                keywordCacheRepository.addUserToKeyword(keyword.getName(), userId));
+                eventPublisher.publishEvent(new KeywordCacheEvent(keyword.getName(), userId, Operation.ADD)));
     }
 
     private boolean hasKeywordBenefit(Long userId) {

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
@@ -4,8 +4,9 @@ import com.keyfeed.keyfeedmonolithic.domain.auth.entity.User;
 import com.keyfeed.keyfeedmonolithic.domain.auth.repository.UserRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.dto.KeywordResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.entity.Keyword;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.event.KeywordCacheEvent;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.event.KeywordCacheEvent.Operation;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.exception.KeywordLimitExceededException;
-import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordCacheRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordRepository;
 import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
 import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -26,6 +28,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -48,7 +51,7 @@ class KeywordServiceImplTest {
     private SubscriptionRepository subscriptionRepository;
 
     @Mock
-    private KeywordCacheRepository keywordCacheRepository;
+    private ApplicationEventPublisher eventPublisher;
 
     private static final int KEYWORD_MAX_COUNT = 3;
     private static final int KEYWORD_SUBSCRIBER_MAX_COUNT = 10;
@@ -96,7 +99,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.ADD)));
     }
 
     @Test
@@ -119,7 +122,7 @@ class KeywordServiceImplTest {
 
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.ADD)));
     }
 
     @Test
@@ -141,7 +144,7 @@ class KeywordServiceImplTest {
                 .hasMessageContaining("최대 10개까지 이용하실 수 있습니다");
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     @Test
@@ -162,7 +165,7 @@ class KeywordServiceImplTest {
                 .isInstanceOf(KeywordLimitExceededException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     // ── 구독자(ACTIVE) ─────────────────────────────────────────────────
@@ -188,7 +191,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.ADD)));
     }
 
     @Test
@@ -210,7 +213,7 @@ class KeywordServiceImplTest {
                 .hasMessageContaining("키워드 등록 한도(10개)에 도달했습니다");
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     @Test
@@ -234,7 +237,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.ADD)));
     }
 
     // ── 구독자(CANCELED, 만료 전) ─────────────────────────────────────
@@ -260,7 +263,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.ADD)));
     }
 
     @Test
@@ -281,7 +284,7 @@ class KeywordServiceImplTest {
                 .isInstanceOf(KeywordLimitExceededException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     // ── 공통 예외 ──────────────────────────────────────────────────────
@@ -303,7 +306,7 @@ class KeywordServiceImplTest {
 
         then(subscriptionRepository).should(never()).existsByUserIdAndStatusIn(any(), any());
         then(keywordRepository).should(never()).save(any(Keyword.class));
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     @Test
@@ -319,7 +322,7 @@ class KeywordServiceImplTest {
                 .isInstanceOf(EntityNotFoundException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     // ── Redis 동기화 ───────────────────────────────────────────────────
@@ -343,7 +346,7 @@ class KeywordServiceImplTest {
         keywordService.addKeyword(userId, keywordName);
 
         // then
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.ADD)));
     }
 
     @Test
@@ -363,7 +366,7 @@ class KeywordServiceImplTest {
 
         // then
         then(keywordRepository).should(times(1)).delete(keyword);
-        then(keywordCacheRepository).should(times(1)).removeUserFromKeyword(eq(keywordName), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.REMOVE)));
     }
 
     @Test
@@ -379,7 +382,7 @@ class KeywordServiceImplTest {
         assertThatThrownBy(() -> keywordService.deleteKeyword(userId, keywordId))
                 .isInstanceOf(EntityNotFoundException.class);
 
-        then(keywordCacheRepository).should(never()).removeUserFromKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     @Test
@@ -403,8 +406,8 @@ class KeywordServiceImplTest {
         keywordService.toggleKeywordNotification(userId, keywordId);
 
         // then: false → true 로 토글되었으므로 SADD
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
-        then(keywordCacheRepository).should(never()).removeUserFromKeyword(any(), any());
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.ADD)));
+        then(eventPublisher).should(never()).publishEvent(argThat((Object e) -> e instanceof KeywordCacheEvent ke && ke.operation() == Operation.REMOVE));
     }
 
     @Test
@@ -424,8 +427,8 @@ class KeywordServiceImplTest {
         keywordService.toggleKeywordNotification(userId, keywordId);
 
         // then: true → false 로 토글되었으므로 SREM
-        then(keywordCacheRepository).should(times(1)).removeUserFromKeyword(eq(keywordName), eq(userId));
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent(keywordName, userId, Operation.REMOVE)));
+        then(eventPublisher).should(never()).publishEvent(argThat((Object e) -> e instanceof KeywordCacheEvent ke && ke.operation() == Operation.ADD));
     }
 
     // ── deactivateExcessKeywords ───────────────────────────────────────
@@ -511,10 +514,10 @@ class KeywordServiceImplTest {
         keywordService.deactivateExcessKeywords(userId, 3);
 
         // then
-        then(keywordCacheRepository).should(times(1)).removeUserFromKeyword(eq("키워드4"), eq(userId));
-        then(keywordCacheRepository).should(never()).removeUserFromKeyword(eq("키워드1"), eq(userId));
-        then(keywordCacheRepository).should(never()).removeUserFromKeyword(eq("키워드2"), eq(userId));
-        then(keywordCacheRepository).should(never()).removeUserFromKeyword(eq("키워드3"), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent("키워드4", userId, Operation.REMOVE)));
+        then(eventPublisher).should(never()).publishEvent(eq(new KeywordCacheEvent("키워드1", userId, Operation.REMOVE)));
+        then(eventPublisher).should(never()).publishEvent(eq(new KeywordCacheEvent("키워드2", userId, Operation.REMOVE)));
+        then(eventPublisher).should(never()).publishEvent(eq(new KeywordCacheEvent("키워드3", userId, Operation.REMOVE)));
     }
 
     @Test
@@ -541,7 +544,7 @@ class KeywordServiceImplTest {
         keywordService.deactivateExcessKeywords(userId, 3);
 
         // then
-        then(keywordCacheRepository).should(never()).removeUserFromKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 
     // ── reactivateAllKeywords ─────────────────────────────────────────
@@ -580,8 +583,8 @@ class KeywordServiceImplTest {
 
         // then
         then(keywordRepository).should(times(1)).enableAllByUserId(userId);
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq("키워드4"), eq(userId));
-        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq("키워드5"), eq(userId));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent("키워드4", userId, Operation.ADD)));
+        then(eventPublisher).should(times(1)).publishEvent(eq(new KeywordCacheEvent("키워드5", userId, Operation.ADD)));
     }
 
     @Test
@@ -597,6 +600,6 @@ class KeywordServiceImplTest {
 
         // then
         then(keywordRepository).should(times(1)).enableAllByUserId(userId);
-        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+        then(eventPublisher).should(never()).publishEvent(any(KeywordCacheEvent.class));
     }
 }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
@@ -492,6 +492,58 @@ class KeywordServiceImplTest {
         // then: 예외 없이 정상 종료
     }
 
+    @Test
+    @DisplayName("비활성화 - 초과 키워드가 알림 ON이면 Redis SREM 호출")
+    void 구독_만료_초과_키워드_비활성화시_Redis_SREM_호출() {
+        // given
+        Long userId = 30L;
+        User user = makeUser(userId);
+        List<Keyword> keywords = List.of(
+                makeKeyword(1L, user, "키워드1"),
+                makeKeyword(2L, user, "키워드2"),
+                makeKeyword(3L, user, "키워드3"),
+                makeKeyword(4L, user, "키워드4")  // 초과 - 알림 ON
+        );
+
+        given(keywordRepository.findByUserIdOrderByCreatedAtAsc(userId)).willReturn(keywords);
+
+        // when
+        keywordService.deactivateExcessKeywords(userId, 3);
+
+        // then
+        then(keywordCacheRepository).should(times(1)).removeUserFromKeyword(eq("키워드4"), eq(userId));
+        then(keywordCacheRepository).should(never()).removeUserFromKeyword(eq("키워드1"), eq(userId));
+        then(keywordCacheRepository).should(never()).removeUserFromKeyword(eq("키워드2"), eq(userId));
+        then(keywordCacheRepository).should(never()).removeUserFromKeyword(eq("키워드3"), eq(userId));
+    }
+
+    @Test
+    @DisplayName("비활성화 - 초과 키워드가 알림 OFF이면 Redis SREM 미호출")
+    void 구독_만료_초과_키워드_비활성화시_알림_OFF_키워드는_Redis_미호출() {
+        // given
+        Long userId = 31L;
+        User user = makeUser(userId);
+        Keyword notificationOffKeyword = Keyword.builder()
+                .user(user)
+                .name("알림OFF키워드")
+                .isNotificationEnabled(false)
+                .build();
+        List<Keyword> keywords = List.of(
+                makeKeyword(1L, user, "키워드1"),
+                makeKeyword(2L, user, "키워드2"),
+                makeKeyword(3L, user, "키워드3"),
+                notificationOffKeyword  // 초과 - 알림 OFF
+        );
+
+        given(keywordRepository.findByUserIdOrderByCreatedAtAsc(userId)).willReturn(keywords);
+
+        // when
+        keywordService.deactivateExcessKeywords(userId, 3);
+
+        // then
+        then(keywordCacheRepository).should(never()).removeUserFromKeyword(any(), any());
+    }
+
     // ── reactivateAllKeywords ─────────────────────────────────────────
 
     @Test
@@ -499,11 +551,52 @@ class KeywordServiceImplTest {
     void 비활성화된_키워드_전체_복원() {
         // given
         Long userId = 14L;
+        given(keywordRepository.findByUserIdAndIsEnabledFalseAndIsNotificationEnabledTrue(userId))
+                .willReturn(List.of());
 
         // when
         keywordService.reactivateAllKeywords(userId);
 
         // then
         then(keywordRepository).should(times(1)).enableAllByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("재구독 - 비활성화된 키워드 복원 시 Redis SADD 호출")
+    void 재구독_키워드_복원시_Redis_SADD_호출() {
+        // given
+        Long userId = 32L;
+        User user = makeUser(userId);
+        List<Keyword> disabledKeywords = List.of(
+                makeKeyword(4L, user, "키워드4"),
+                makeKeyword(5L, user, "키워드5")
+        );
+
+        given(keywordRepository.findByUserIdAndIsEnabledFalseAndIsNotificationEnabledTrue(userId))
+                .willReturn(disabledKeywords);
+
+        // when
+        keywordService.reactivateAllKeywords(userId);
+
+        // then
+        then(keywordRepository).should(times(1)).enableAllByUserId(userId);
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq("키워드4"), eq(userId));
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq("키워드5"), eq(userId));
+    }
+
+    @Test
+    @DisplayName("재구독 - 복원할 키워드 없으면 Redis SADD 미호출")
+    void 복원할_키워드_없으면_Redis_미호출() {
+        // given
+        Long userId = 33L;
+        given(keywordRepository.findByUserIdAndIsEnabledFalseAndIsNotificationEnabledTrue(userId))
+                .willReturn(List.of());
+
+        // when
+        keywordService.reactivateAllKeywords(userId);
+
+        // then
+        then(keywordRepository).should(times(1)).enableAllByUserId(userId);
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
     }
 }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/keyword/service/impl/KeywordServiceImplTest.java
@@ -5,6 +5,7 @@ import com.keyfeed.keyfeedmonolithic.domain.auth.repository.UserRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.dto.KeywordResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.entity.Keyword;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.exception.KeywordLimitExceededException;
+import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordCacheRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordRepository;
 import com.keyfeed.keyfeedmonolithic.domain.payment.entity.SubscriptionStatus;
 import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -44,6 +46,9 @@ class KeywordServiceImplTest {
 
     @Mock
     private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private KeywordCacheRepository keywordCacheRepository;
 
     private static final int KEYWORD_MAX_COUNT = 3;
     private static final int KEYWORD_SUBSCRIBER_MAX_COUNT = 10;
@@ -91,6 +96,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
     }
 
     @Test
@@ -113,6 +119,7 @@ class KeywordServiceImplTest {
 
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
     }
 
     @Test
@@ -134,6 +141,7 @@ class KeywordServiceImplTest {
                 .hasMessageContaining("최대 10개까지 이용하실 수 있습니다");
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
     }
 
     @Test
@@ -154,6 +162,7 @@ class KeywordServiceImplTest {
                 .isInstanceOf(KeywordLimitExceededException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
     }
 
     // ── 구독자(ACTIVE) ─────────────────────────────────────────────────
@@ -179,6 +188,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
     }
 
     @Test
@@ -200,6 +210,7 @@ class KeywordServiceImplTest {
                 .hasMessageContaining("키워드 등록 한도(10개)에 도달했습니다");
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
     }
 
     @Test
@@ -223,6 +234,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
     }
 
     // ── 구독자(CANCELED, 만료 전) ─────────────────────────────────────
@@ -248,6 +260,7 @@ class KeywordServiceImplTest {
         // then
         assertThat(result.getName()).isEqualTo(keywordName);
         then(keywordRepository).should(times(1)).save(any(Keyword.class));
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
     }
 
     @Test
@@ -268,6 +281,7 @@ class KeywordServiceImplTest {
                 .isInstanceOf(KeywordLimitExceededException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
     }
 
     // ── 공통 예외 ──────────────────────────────────────────────────────
@@ -289,6 +303,7 @@ class KeywordServiceImplTest {
 
         then(subscriptionRepository).should(never()).existsByUserIdAndStatusIn(any(), any());
         then(keywordRepository).should(never()).save(any(Keyword.class));
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
     }
 
     @Test
@@ -304,6 +319,113 @@ class KeywordServiceImplTest {
                 .isInstanceOf(EntityNotFoundException.class);
 
         then(keywordRepository).should(never()).save(any(Keyword.class));
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
+    }
+
+    // ── Redis 동기화 ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("키워드 등록 시 Redis SADD 호출")
+    void 키워드_등록시_Redis_SADD_호출() {
+        // given
+        Long userId = 20L;
+        String keywordName = "레디스";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(1L, user, keywordName);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(keywordRepository.existsByNameAndUser(keywordName, user)).willReturn(false);
+        given(subscriptionRepository.existsByUserIdAndStatusIn(userId, List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED))).willReturn(false);
+        given(keywordRepository.countByUserIdAndIsEnabledTrue(userId)).willReturn(1L);
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        keywordService.addKeyword(userId, keywordName);
+
+        // then
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+    }
+
+    @Test
+    @DisplayName("키워드 삭제 시 Redis SREM 호출")
+    void 키워드_삭제시_Redis_SREM_호출() {
+        // given
+        Long userId = 21L;
+        Long keywordId = 100L;
+        String keywordName = "삭제키워드";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(keywordId, user, keywordName);
+
+        given(keywordRepository.findByIdAndUserId(keywordId, userId)).willReturn(Optional.of(keyword));
+
+        // when
+        keywordService.deleteKeyword(userId, keywordId);
+
+        // then
+        then(keywordRepository).should(times(1)).delete(keyword);
+        then(keywordCacheRepository).should(times(1)).removeUserFromKeyword(eq(keywordName), eq(userId));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 키워드 삭제 시 EntityNotFoundException 발생, Redis 미호출")
+    void 존재하지않는_키워드_삭제시_예외_발생_Redis_미호출() {
+        // given
+        Long userId = 22L;
+        Long keywordId = 999L;
+
+        given(keywordRepository.findByIdAndUserId(keywordId, userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.deleteKeyword(userId, keywordId))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        then(keywordCacheRepository).should(never()).removeUserFromKeyword(any(), any());
+    }
+
+    @Test
+    @DisplayName("알림 ON 전환 시 Redis SADD 호출")
+    void 알림_ON_전환시_Redis_SADD_호출() {
+        // given
+        Long userId = 23L;
+        Long keywordId = 200L;
+        String keywordName = "토글온";
+        User user = makeUser(userId);
+        Keyword keyword = Keyword.builder()
+                .user(user)
+                .name(keywordName)
+                .isNotificationEnabled(false)
+                .build();
+
+        given(keywordRepository.findByIdAndUserId(keywordId, userId)).willReturn(Optional.of(keyword));
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        keywordService.toggleKeywordNotification(userId, keywordId);
+
+        // then: false → true 로 토글되었으므로 SADD
+        then(keywordCacheRepository).should(times(1)).addUserToKeyword(eq(keywordName), eq(userId));
+        then(keywordCacheRepository).should(never()).removeUserFromKeyword(any(), any());
+    }
+
+    @Test
+    @DisplayName("알림 OFF 전환 시 Redis SREM 호출")
+    void 알림_OFF_전환시_Redis_SREM_호출() {
+        // given
+        Long userId = 24L;
+        Long keywordId = 201L;
+        String keywordName = "토글오프";
+        User user = makeUser(userId);
+        Keyword keyword = makeKeyword(keywordId, user, keywordName); // isNotificationEnabled = true
+
+        given(keywordRepository.findByIdAndUserId(keywordId, userId)).willReturn(Optional.of(keyword));
+        given(keywordRepository.save(any(Keyword.class))).willReturn(keyword);
+
+        // when
+        keywordService.toggleKeywordNotification(userId, keywordId);
+
+        // then: true → false 로 토글되었으므로 SREM
+        then(keywordCacheRepository).should(times(1)).removeUserFromKeyword(eq(keywordName), eq(userId));
+        then(keywordCacheRepository).should(never()).addUserToKeyword(any(), any());
     }
 
     // ── deactivateExcessKeywords ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- `KeywordCacheRepository` 추가 — Redis Set으로 키워드별 구독 유저 목록 관리 (`keyword:users:{keyword}` 키)
- `KeywordServiceImpl` 수정 — 키워드 등록/삭제/알림 토글 시 Redis SADD/SREM 동기화
- `KeywordRepository` 수정 — 비활성화 상태 키워드 조회 메서드 추가
- `KeywordServiceImpl` 수정 — 구독 만료/재구독 시 `deactivateExcessKeywords`, `reactivateAllKeywords`에 Redis 캐시 동기화 추가
- `KeywordCacheEvent` / `KeywordCacheEventListener` 추가 — `@TransactionalEventListener`로 DB 커밋 완료 후 Redis 업데이트하도록 개선 (트랜잭션 롤백 시 Redis 불일치 방지)
- `KeywordServiceImplTest` 수정 — Redis 캐시 동기화 및 이벤트 발행 관련 단위 테스트 추가

## Test plan
- [ ] 키워드 등록 시 알림 활성화 상태이면 Redis SADD 이벤트 발행 확인
- [ ] 키워드 삭제 시 Redis SREM 이벤트 발행 확인
- [ ] 알림 ON 전환 시 Redis SADD, OFF 전환 시 Redis SREM 이벤트 발행 확인
- [ ] 구독 만료 시 초과 키워드 비활성화 시 Redis SREM 이벤트 발행 확인
- [ ] 재구독 시 키워드 복원 시 Redis SADD 이벤트 발행 확인
- [ ] 유효하지 않은 키워드 조작 시 예외 발생 및 Redis 이벤트 미발행 확인