### PR TITLE
[FEAT] 이메일 인증 코드 전송 비동기 처리

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/auth/service/impl/EmailVerificationServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/auth/service/impl/EmailVerificationServiceImpl.java
@@ -12,10 +12,11 @@ import com.keyfeed.keyfeedmonolithic.domain.auth.repository.EmailVerificationRep
 import com.keyfeed.keyfeedmonolithic.domain.auth.service.EmailVerificationService;
 import com.keyfeed.keyfeedmonolithic.domain.auth.util.VerificationCodeUtil;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundException;
-import com.keyfeed.keyfeedmonolithic.global.mail.EmailClient;
+import com.keyfeed.keyfeedmonolithic.global.mail.EmailSendEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.context.Context;
@@ -42,7 +43,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     private final EmailVerificationRepository emailVerificationRepository;
     private final SpringTemplateEngine templateEngine;
-    private final EmailClient emailClient;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public void sendVerificationEmail(String email, EmailPurpose purpose, String subject) {
@@ -180,7 +181,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
 
     private void sendEmail(String email, String code, String subject) {
         String html = buildVerificationHtml(email, code);
-        emailClient.sendOneEmail(email, subject, html);
+        eventPublisher.publishEvent(new EmailSendEvent(email, subject, html));
     }
 
     private EmailVerification saveNewEmailVerification(String email, String code, LocalDateTime now, EmailPurpose purpose) {

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/AsyncConfig.java
@@ -22,6 +22,8 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setMaxPoolSize(10);
         executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("email-async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(10);
         executor.initialize();
         return executor;
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/AsyncConfig.java
@@ -1,0 +1,34 @@
+package com.keyfeed.keyfeedmonolithic.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean("emailTaskExecutor")
+    public Executor emailTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("email-async-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("[Async 예외] method={}", method.getName(), ex);
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailClient.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailClient.java
@@ -26,11 +26,20 @@ public class EmailClient {
             mimeMessageHelper.setText(text, true);
 
             mailSender.send(mimeMessage);
+            log.info("이메일 발송 완료. to={}, subject={}", maskEmail(to), subject);
 
         } catch (MessagingException e){
-            log.error("Error sending email", e);
+            log.error("이메일 발송 실패. to={}, subject={}", maskEmail(to), subject, e);
             throw new EmailSendFailedException();
         }
+    }
+
+    private String maskEmail(String email) {
+        int at = email.indexOf('@');
+        if (at <= 2) {
+            return "***" + email.substring(at);
+        }
+        return email.substring(0, 2) + "***" + email.substring(at);
     }
 
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailClient.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailClient.java
@@ -35,7 +35,13 @@ public class EmailClient {
     }
 
     private String maskEmail(String email) {
+        if (email == null) {
+            return "";
+        }
         int at = email.indexOf('@');
+        if (at == -1) {
+            return email.length() <= 2 ? "***" : email.substring(0, 2) + "***";
+        }
         if (at <= 2) {
             return "***" + email.substring(at);
         }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailSendEvent.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailSendEvent.java
@@ -1,0 +1,4 @@
+package com.keyfeed.keyfeedmonolithic.global.mail;
+
+public record EmailSendEvent(String to, String subject, String html) {
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailSendEventListener.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/mail/EmailSendEventListener.java
@@ -1,0 +1,20 @@
+package com.keyfeed.keyfeedmonolithic.global.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class EmailSendEventListener {
+
+    private final EmailClient emailClient;
+
+    @Async("emailTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(EmailSendEvent event) {
+        emailClient.sendOneEmail(event.to(), event.subject(), event.html());
+    }
+}

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/auth/service/impl/EmailVerificationServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/auth/service/impl/EmailVerificationServiceImplTest.java
@@ -1,0 +1,141 @@
+package com.keyfeed.keyfeedmonolithic.domain.auth.service.impl;
+
+import com.keyfeed.keyfeedmonolithic.domain.auth.entity.EmailPurpose;
+import com.keyfeed.keyfeedmonolithic.domain.auth.entity.EmailVerification;
+import com.keyfeed.keyfeedmonolithic.domain.auth.entity.EmailVerifyStatus;
+import com.keyfeed.keyfeedmonolithic.domain.auth.exception.EmailVerificationAlreadyDoneException;
+import com.keyfeed.keyfeedmonolithic.domain.auth.exception.EmailVerificationLockedException;
+import com.keyfeed.keyfeedmonolithic.domain.auth.repository.EmailVerificationRepository;
+import com.keyfeed.keyfeedmonolithic.global.mail.EmailSendEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceImplTest {
+
+    @InjectMocks
+    private EmailVerificationServiceImpl emailVerificationService;
+
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
+    private SpringTemplateEngine templateEngine;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private static final String EMAIL = "test@keyfeed.com";
+    private static final String SUBJECT = "[Key Feed] 인증번호";
+    private static final String HTML = "<html>code</html>";
+    private static final int EXPIRE_MINUTES = 5;
+    private static final int LOCK_MINUTES = 15;
+    private static final int MAX_ATTEMPTS = 5;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(emailVerificationService, "expireMinutes", EXPIRE_MINUTES);
+        ReflectionTestUtils.setField(emailVerificationService, "lockMinutes", LOCK_MINUTES);
+        ReflectionTestUtils.setField(emailVerificationService, "maxAttempts", MAX_ATTEMPTS);
+    }
+
+    @Test
+    @DisplayName("신규 인증 요청 시 인증 정보를 저장하고 메일 발송 이벤트를 발행한다")
+    void 신규_인증_요청시_이벤트_발행() {
+        // given
+        given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                .willReturn(Optional.empty());
+        given(templateEngine.process(eq("email/verification"), any(Context.class))).willReturn(HTML);
+
+        // when
+        emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT);
+
+        // then
+        then(emailVerificationRepository).should().save(any(EmailVerification.class));
+        then(eventPublisher).should().publishEvent(new EmailSendEvent(EMAIL, SUBJECT, HTML));
+    }
+
+    @Test
+    @DisplayName("기존 PENDING(미만료) 인증이 있으면 코드를 갱신하고 메일 발송 이벤트를 발행한다")
+    void 기존_미만료_인증_재요청시_이벤트_발행() {
+        // given
+        EmailVerification existing = EmailVerification.builder()
+                .email(EMAIL)
+                .purpose(EmailPurpose.SIGNUP)
+                .code("000000")
+                .status(EmailVerifyStatus.PENDING)
+                .expiresAt(LocalDateTime.now().plusMinutes(EXPIRE_MINUTES))
+                .build();
+        given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                .willReturn(Optional.of(existing));
+        given(templateEngine.process(eq("email/verification"), any(Context.class))).willReturn(HTML);
+
+        // when
+        emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT);
+
+        // then
+        then(eventPublisher).should().publishEvent(new EmailSendEvent(EMAIL, SUBJECT, HTML));
+    }
+
+    @Test
+    @DisplayName("이미 인증 완료된 이메일이면 예외를 던지고 메일 발송 이벤트를 발행하지 않는다")
+    void 이미_인증완료시_이벤트_미발행() {
+        // given
+        EmailVerification verified = EmailVerification.builder()
+                .email(EMAIL)
+                .purpose(EmailPurpose.SIGNUP)
+                .status(EmailVerifyStatus.VERIFIED)
+                .expiresAt(LocalDateTime.now().plusMinutes(EXPIRE_MINUTES))
+                .build();
+        given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                .willReturn(Optional.of(verified));
+
+        // when & then
+        assertThatThrownBy(() ->
+                emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT))
+                .isInstanceOf(EmailVerificationAlreadyDoneException.class);
+
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("잠금 상태이고 잠금 시간이 지나지 않았으면 예외를 던지고 메일 발송 이벤트를 발행하지 않는다")
+    void 잠금상태시_이벤트_미발행() {
+        // given
+        EmailVerification locked = EmailVerification.builder()
+                .email(EMAIL)
+                .purpose(EmailPurpose.SIGNUP)
+                .status(EmailVerifyStatus.LOCKED)
+                .lockedUntil(LocalDateTime.now().plusMinutes(LOCK_MINUTES))
+                .expiresAt(LocalDateTime.now().plusMinutes(EXPIRE_MINUTES))
+                .build();
+        given(emailVerificationRepository.findTopByEmailAndPurposeOrderByIdDesc(EMAIL, EmailPurpose.SIGNUP))
+                .willReturn(Optional.of(locked));
+
+        // when & then
+        assertThatThrownBy(() ->
+                emailVerificationService.sendVerificationEmail(EMAIL, EmailPurpose.SIGNUP, SUBJECT))
+                .isInstanceOf(EmailVerificationLockedException.class);
+
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+}


### PR DESCRIPTION
## Summary
- `AsyncConfig` 추가 — `@EnableAsync` + 전용 `emailTaskExecutor`(core 2 / max 10 / queue 100) + `AsyncUncaughtExceptionHandler`
- `EmailSendEvent` 추가 — 렌더링된 메일 정보(`to`, `subject`, `html`)를 담는 도메인 무관 이벤트
- `EmailSendEventListener` 추가 — `@Async` + `@TransactionalEventListener(AFTER_COMMIT)`로 트랜잭션 커밋 후 별도 스레드에서 메일 발송
- `EmailVerificationServiceImpl` 수정 — `EmailClient` 직접 호출 대신 `EmailSendEvent` 발행으로 전환
- `EmailClient` 수정 — 발송 성공/실패 로그 추가 및 이메일 주소 마스킹 처리
- `EmailVerificationServiceImplTest` 추가 — 메일 발송 이벤트 발행/미발행 단위 테스트

## 배경
기존에는 `EmailClient.sendOneEmail()`이 SMTP 완료까지 동기 블로킹되어, 메일 서버 지연/장애 시 API 응답이 느려지고 톰캣 워커 스레드가 묶였다. 인증 코드 DB 저장이 커밋된 경우에만 메일이 발송되도록 하여 정합성을 보장하면서, 발송 자체는 비동기로 분리했다.

## Test plan
- [ ] 신규 인증 요청 시 인증 정보 저장 및 메일 발송 이벤트 발행 확인
- [ ] 기존 PENDING(미만료) 인증 재요청 시 코드 갱신 및 이벤트 발행 확인
- [ ] 이미 인증 완료된 이메일 재요청 시 예외 발생 및 이벤트 미발행 확인
- [ ] 잠금 상태(잠금 시간 미경과) 재요청 시 예외 발생 및 이벤트 미발행 확인
- [ ] 로컬 실행으로 응답이 SMTP 대기 없이 즉시 반환되고 `email-async-` 스레드에서 발송되는지 확인
- [ ] 트랜잭션 롤백 시 메일이 발송되지 않는지 확인

Closes #39
