### PR TITLE
chore(backend): DB 마이그레이션 도구 Flyway 도입

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
 
+    // flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     // p6spy
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
@@ -132,9 +132,13 @@ public class FeedServiceImpl implements FeedService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
-        Map<String, Long> bookmarkMap = bookmarkService.getBookmarkMap(userId, contentIds);
-        if (bookmarkMap != null) {
-            feeds.forEach(feed -> feed.setBookmarkId(bookmarkMap.get(feed.getContentId())));
+        try {
+            Map<String, Long> bookmarkMap = bookmarkService.getBookmarkMap(userId, contentIds);
+            if (bookmarkMap != null) {
+                feeds.forEach(feed -> feed.setBookmarkId(bookmarkMap.get(feed.getContentId())));
+            }
+        } catch (Exception e) {
+            log.warn("북마크 상태 조회 실패 - 북마크 없이 피드를 반환합니다. userId={}", userId, e);
         }
     }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,6 +12,12 @@ spring:
     hibernate:
       ddl-auto: validate
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true   # 기존(비어있지 않은) DB는 V1로 baseline 처리 후 V2+ 적용
+    baseline-version: 1
+    locations: classpath:db/migration
+
   thymeleaf:
     cache: false
     prefix: classpath:/templates/

--- a/backend/src/main/resources/db/migration/V1__baseline.sql
+++ b/backend/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,201 @@
+create table `user` (
+    user_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    customer_key varchar(200),
+    email varchar(120),
+    is_social bit not null,
+    is_withdraw bit not null,
+    last_notification_checked_at datetime(6),
+    password varchar(255),
+    role enum ('ADMIN','USER'),
+    setting_push bit not null,
+    sns_type varchar(255),
+    username varchar(60),
+    primary key (user_id)
+) engine=InnoDB;
+
+create table source (
+    source_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    last_crawled_at datetime(6),
+    last_item_hash varchar(255),
+    logo_url varchar(2048),
+    url varchar(767) not null,
+    primary key (source_id),
+    constraint uk_source_url unique (url)
+) engine=InnoDB;
+
+create table content (
+    content_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    original_url varchar(2048),
+    published_at datetime(6) not null,
+    source_id bigint not null,
+    source_name varchar(255),
+    summary text not null,
+    thumbnail_url varchar(2048),
+    title varchar(512) not null,
+    primary key (content_id)
+) engine=InnoDB;
+
+create table email_verification (
+    id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    attempt_count integer,
+    code varchar(6),
+    email varchar(255),
+    expires_at datetime(6),
+    locked_until datetime(6),
+    purpose enum ('CHANGE','RESET','SIGNUP'),
+    status enum ('EXPIRED','LOCKED','PENDING','VERIFIED'),
+    primary key (id)
+) engine=InnoDB;
+
+create table notification (
+    notification_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    content_id bigint,
+    is_read bit not null,
+    message varchar(255),
+    title varchar(255),
+    original_url varchar(255),
+    user_id bigint,
+    primary key (notification_id)
+) engine=InnoDB;
+
+create table notification_processed_contents (
+    content_id bigint not null,
+    processed_at datetime(6) not null,
+    primary key (content_id)
+) engine=InnoDB;
+
+create table outbox (
+    id bigint not null auto_increment,
+    aggregate_id bigint not null,
+    aggregate_type varchar(255) not null,
+    created_at datetime(6) not null,
+    error_message text,
+    event_type varchar(255) not null,
+    idempotency_key varchar(255),
+    last_tried_at datetime(6),
+    max_retry integer not null,
+    next_retry_at datetime(6),
+    payload json not null,
+    published_at datetime(6),
+    retry_count integer not null,
+    status enum ('FAILED','PENDING','PUBLISHED') not null,
+    primary key (id),
+    constraint uk_idempotency_key unique (idempotency_key)
+) engine=InnoDB;
+
+create table bookmark_folder (
+    bookmark_folder_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    color varchar(20),
+    icon varchar(50),
+    name varchar(100) not null,
+    user_id bigint not null,
+    primary key (bookmark_folder_id),
+    constraint uk_folder_user_name unique (user_id, name),
+    constraint fk_bookmark_folder_user foreign key (user_id) references `user` (user_id)
+) engine=InnoDB;
+
+create table bookmark (
+    bookmark_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    content_id varchar(255) not null,
+    bookmark_folder_id bigint,
+    user_id bigint not null,
+    primary key (bookmark_id),
+    constraint uk_bookmark_user_content unique (user_id, content_id),
+    constraint fk_bookmark_user foreign key (user_id) references `user` (user_id),
+    constraint fk_bookmark_folder foreign key (bookmark_folder_id) references bookmark_folder (bookmark_folder_id)
+) engine=InnoDB;
+
+create table keyword (
+    keyword_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    is_enabled bit not null,
+    is_notification_enabled bit not null,
+    name varchar(255),
+    user_id bigint,
+    primary key (keyword_id),
+    constraint fk_keyword_user foreign key (user_id) references `user` (user_id)
+) engine=InnoDB;
+
+create table payment_method (
+    method_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    billing_key varchar(300) not null,
+    deleted_at datetime(6),
+    display_number varchar(100),
+    is_active bit not null,
+    is_default bit not null,
+    method_type enum ('BANK','CARD') not null,
+    provider_name varchar(100),
+    user_id bigint not null,
+    primary key (method_id),
+    constraint fk_payment_method_user foreign key (user_id) references `user` (user_id)
+) engine=InnoDB;
+
+create table user_source (
+    user_source_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    receive_feed bit not null,
+    user_defined_name varchar(100) not null,
+    source_id bigint not null,
+    user_id bigint not null,
+    primary key (user_source_id),
+    constraint fk_user_source_user foreign key (user_id) references `user` (user_id),
+    constraint fk_user_source_source foreign key (source_id) references source (source_id)
+) engine=InnoDB;
+
+create table subscription (
+    subscription_id bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    canceled_at datetime(6),
+    expired_at datetime(6),
+    next_billing_at datetime(6),
+    order_name varchar(255) not null,
+    price integer not null,
+    retry_count integer not null,
+    started_at datetime(6),
+    status enum ('ACTIVE','CANCELED','INACTIVE','PAUSED','PENDING','REFUNDED') not null,
+    method_id bigint,
+    user_id bigint not null,
+    primary key (subscription_id),
+    constraint fk_subscription_user foreign key (user_id) references `user` (user_id),
+    constraint fk_subscription_method foreign key (method_id) references payment_method (method_id)
+) engine=InnoDB;
+
+create table payment_history (
+    payment_id bigint not null auto_increment,
+    amount integer not null,
+    approved_at datetime(6),
+    created_at datetime(6),
+    fail_reason text,
+    method_type enum ('BANK','CARD'),
+    order_id varchar(100) not null,
+    order_name varchar(255),
+    payment_key varchar(255),
+    status enum ('ABORTED','CANCELED','DONE','EXPIRED','FAILED','IN_PROGRESS','PARTIAL_CANCELED','READY') not null,
+    method_id bigint,
+    subscription_id bigint,
+    user_id bigint not null,
+    primary key (payment_id),
+    constraint uk_payment_history_order_id unique (order_id),
+    constraint fk_payment_history_user foreign key (user_id) references `user` (user_id),
+    constraint fk_payment_history_subscription foreign key (subscription_id) references subscription (subscription_id),
+    constraint fk_payment_history_method foreign key (method_id) references payment_method (method_id)
+) engine=InnoDB;

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -5,8 +5,13 @@ spring:
     username: sa
     password:
 
+  flyway:
+    enabled: false   # 테스트는 H2 사용 → MySQL 전용 마이그레이션 미적용, Hibernate가 스키마 생성
+
   jpa:
     show-sql: true
+    hibernate:
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
@@ -39,9 +44,17 @@ jasypt:
     password: test_password
     bean: jasyptEncryptor
 
+jwt:
+  secret: jwt_key
+  expiration_time: 600000
+  refresh_expiration_time: 1209600000
+
 app:
   limits:
     keyword-max-count: 3
     keyword-subscriber-max-count: 10
     folder-max-count: 3
     folder-subscriber-max-count: 20
+
+cors:
+  allowed-origins: http://localhost:3000


### PR DESCRIPTION
## 개요
이슈 #73 — DDL 변경을 코드로 관리하기 위해 Flyway를 선행 도입합니다. Hibernate는 `validate`로 검증만 수행하고, 스키마 생성·변경은 Flyway가 담당합니다. (후속 #55 ShedLock 테이블 추가의 선행 작업)

## 변경 사항
### Flyway 도입 (`chore`)
- `build.gradle`: `flyway-core`, `flyway-mysql` 의존성 추가
- `application.yml`: `spring.flyway` 설정 추가 (`baseline-on-migrate: true`, `baseline-version: 1`, `locations: classpath:db/migration`)
- `db/migration/V1__baseline.sql`: 기존 스키마 baseline (14개 테이블). Hibernate(MySQLDialect) 생성 결과를 FK 의존 순서로 재정렬하고 제약/인덱스명을 명시 → `validate`와 정확히 일치
- 테스트(H2): `spring.flyway.enabled: false` + `ddl-auto: create-drop` (MySQL 전용 DDL 미적용, Hibernate가 스키마 생성). 누락돼 있던 `cors`·`jwt` 테스트 프로퍼티 보완
- `docs/flyway.md`: 운영 적용 가이드 문서화

### 버그 수정 (`fix`)
- `FeedServiceImpl.attachBookmarkStatus`: 북마크 서비스 조회 실패 시 예외를 삼키고 피드를 정상 반환하도록 처리 (기존에 테스트만 있고 프로덕션 대응이 누락돼 있던 건)

## 동작 방식
- **기존 운영/로컬 DB**(테이블 존재): `baseline-on-migrate`로 V1 baseline 처리, V1 미실행 → V2부터 적용
- **신규(빈) DB**: V1부터 전체 마이그레이션 적용

## 검증
- `./gradlew test` — 144개 전부 통과
- ⚠️ 로컬 MySQL 실적용 검증(`bootRun --spring.profiles.active=local`)은 환경 제약으로 미수행. baseline은 앱과 동일한 Hibernate로 생성해 `validate` 일치를 보장하나, 머지 전 실 MySQL에서 한 번 확인 권장 (절차는 `docs/flyway.md` 참고)

Closes #73