### PR TITLE
feat(frontend): 로그인 화면 디자인 시스템 적용

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,10 +10,11 @@
   <!-- SEO Meta Tags -->
   <meta name="description" content="A beautiful and dynamic mobile feed experience built with React and Vite." />
   <meta name="theme-color" content="#121212" />
-  <!-- Google Fonts: Inter -->
+  <!-- Google Fonts: Inter, Space Grotesk (display), Space Mono (mono labels) + Pretendard (KR body) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@1.3.9/dist/web/static/pretendard.min.css" rel="stylesheet">
 </head>
 
 <body>

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,13 +1,18 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Mail, Lock, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { AuthWrapper } from '@/components/ui/AuthWrapper';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { cn } from '@/utils/cn';
 import { useAuthStore } from '@/stores/authStore';
 import { useLogin } from '../hooks/useLogin';
 import type { LoginRequest } from '../types/auth.types';
+
+// Brand wordmark shown top-left. (Design mock uses "tracer" — swap to your brand.)
+const BRAND = 'tracer';
 
 const loginSchema = z.object({
     email: z.string().min(1, '이메일을 입력해주세요.').email('올바른 이메일 형식이 아닙니다.'),
@@ -16,11 +21,18 @@ const loginSchema = z.object({
 
 type LoginFormValues = z.infer<typeof loginSchema>;
 
+// Exact field styling from the Claude Design login screen.
+const inputClass =
+    'w-full h-[50px] border border-hairline rounded-[4px] px-3.5 text-[16px] text-ink ' +
+    'placeholder:text-muted outline-none transition-colors focus:border-form-focus';
+
 export function LoginPage() {
     const navigate = useNavigate();
     const setPendingEmail = useAuthStore((state) => state.setPendingEmail);
     const { mutateAsync: loginMutation, isPending } = useLogin();
     const [loginError, setLoginError] = useState<string | null>(null);
+
+    const screenRef = useRef<HTMLDivElement>(null);
 
     const {
         register,
@@ -28,11 +40,17 @@ export function LoginPage() {
         formState: { errors },
     } = useForm<LoginFormValues>({
         resolver: zodResolver(loginSchema),
-        defaultValues: {
-            email: '',
-            password: '',
-        },
+        defaultValues: { email: '', password: '' },
     });
+
+    // Matches the design's `scrFade` screen entrance.
+    useGSAP(() => {
+        gsap.fromTo(
+            screenRef.current,
+            { opacity: 0, y: 8 },
+            { opacity: 1, y: 0, duration: 0.3, ease: 'power2.out' }
+        );
+    }, []);
 
     const onSubmit = async (data: LoginFormValues) => {
         setLoginError(null);
@@ -41,8 +59,7 @@ export function LoginPage() {
             navigate('/home');
         } catch (error) {
             console.error('Login failed:', error);
-            // In a real app, parse axios error response message
-            const apiError = error as { response?: { status?: number, data?: { message?: string } } };
+            const apiError = error as { response?: { status?: number; data?: { message?: string } } };
             const errorMessage = apiError?.response?.data?.message;
 
             if (apiError?.response?.status === 400 && errorMessage === 'EMAIL_VERIFICATION_REQUIRED') {
@@ -56,58 +73,119 @@ export function LoginPage() {
     };
 
     return (
-        <AuthWrapper title="Login" subtitle="반갑습니다! 로그인 후 서비스를 이용해주세요.">
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-                <div>
-                    <div className="relative group">
-                        <Mail className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
-                        <input
-                            type="email"
-                            placeholder="이메일 주소"
-                            {...register('email')}
-                            className={`w-full bg-white/40 border ${errors.email ? 'border-red-400' : 'border-white/60'} rounded-2xl py-4 pl-12 pr-4 text-sm font-bold focus:ring-4 focus:ring-slate-100 outline-none transition-all placeholder:font-medium`}
-                        />
-                    </div>
-                    {errors.email && <p className="text-red-500 text-xs mt-1.5 ml-2 font-bold">{errors.email.message}</p>}
-                </div>
+        <div ref={screenRef} className="flex min-h-screen flex-col bg-canvas font-pretendard text-ink">
+            {/* Logo header */}
+            <div className="flex items-center gap-2 px-5 py-6 sm:px-10">
+                <button
+                    type="button"
+                    onClick={() => navigate('/')}
+                    className="flex items-center gap-2"
+                    aria-label={BRAND}
+                >
+                    <span className="h-4 w-4 rounded-[5px] bg-deep-green" />
+                    <span className="font-display text-[21px] font-medium tracking-[-0.4px] text-primary">
+                        {BRAND}
+                    </span>
+                </button>
+            </div>
 
-                <div>
-                    <div className="relative group">
-                        <Lock className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
+            {/* Centered login card */}
+            <div className="flex flex-1 items-center justify-center px-5 pb-20 pt-4">
+                <div className="w-full max-w-[400px]">
+                    <div className="mb-3.5 font-mono text-[12px] uppercase tracking-mono-label text-coral">
+                        LOGIN
+                    </div>
+                    <h1 className="mb-3 font-display text-[32px] font-medium leading-[1.04] tracking-tightest text-primary sm:text-[40px]">
+                        다시 오셨어요
+                    </h1>
+                    <p className="mb-[34px] text-[16px] text-[#616161]">
+                        계정에 로그인하고 피드를 이어보세요.
+                    </p>
+
+                    <form onSubmit={handleSubmit(onSubmit)} noValidate>
+                        <label htmlFor="email" className="mb-[7px] block text-[13px] text-[#616161]">
+                            이메일
+                        </label>
                         <input
+                            id="email"
+                            type="email"
+                            autoComplete="email"
+                            placeholder="you@example.com"
+                            {...register('email')}
+                            className={cn(inputClass, 'mb-5', errors.email && 'border-brand-error focus:border-brand-error')}
+                        />
+                        {errors.email && (
+                            <p className="-mt-3.5 mb-3 text-[13px] text-brand-error">{errors.email.message}</p>
+                        )}
+
+                        <div className="mb-[7px] flex items-baseline justify-between">
+                            <label htmlFor="password" className="text-[13px] text-[#616161]">
+                                비밀번호
+                            </label>
+                            <button
+                                type="button"
+                                className="text-[13px] text-action-blue"
+                                onClick={() => { /* TODO: 비밀번호 재설정 플로우 연결 */ }}
+                            >
+                                비밀번호를 잊으셨나요?
+                            </button>
+                        </div>
+                        <input
+                            id="password"
                             type="password"
+                            autoComplete="current-password"
                             placeholder="비밀번호"
                             {...register('password')}
-                            className={`w-full bg-white/40 border ${errors.password ? 'border-red-400' : 'border-white/60'} rounded-2xl py-4 pl-12 pr-4 text-sm font-bold focus:ring-4 focus:ring-slate-100 outline-none transition-all placeholder:font-medium`}
+                            className={cn(inputClass, 'mb-7', errors.password && 'border-brand-error focus:border-brand-error')}
                         />
+                        {errors.password && (
+                            <p className="-mt-5 mb-3 text-[13px] text-brand-error">{errors.password.message}</p>
+                        )}
+
+                        {loginError && (
+                            <div className="mb-[18px] rounded-[4px] border border-brand-error/20 bg-brand-error/5 px-3.5 py-3 text-[13px] text-brand-error">
+                                {loginError}
+                            </div>
+                        )}
+
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="mb-[18px] flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black disabled:cursor-not-allowed disabled:opacity-70"
+                        >
+                            {isPending ? <Loader2 className="animate-spin" size={20} /> : '로그인'}
+                        </button>
+                    </form>
+
+                    <div className="mb-[18px] flex items-center gap-3">
+                        <div className="h-px flex-1 bg-[#e5e7eb]" />
+                        <span className="text-[13px] text-muted">또는</span>
+                        <div className="h-px flex-1 bg-[#e5e7eb]" />
                     </div>
-                    {errors.password && <p className="text-red-500 text-xs mt-1.5 ml-2 font-bold">{errors.password.message}</p>}
-                </div>
 
-                {loginError && (
-                    <div className="bg-red-50 text-red-500 text-xs font-bold p-3 rounded-xl border border-red-100 text-center">
-                        {loginError}
-                    </div>
-                )}
-
-                <button
-                    type="submit"
-                    disabled={isPending}
-                    className="w-full bg-slate-900 text-white py-4 rounded-2xl font-black text-sm uppercase shadow-xl mt-4 active:scale-95 transition-transform flex items-center justify-center disabled:opacity-70 disabled:active:scale-100"
-                >
-                    {isPending ? <Loader2 className="animate-spin" size={20} /> : '로그인'}
-                </button>
-
-                <div className="text-center pt-4">
                     <button
                         type="button"
-                        onClick={() => navigate('/auth/signup')}
-                        className="text-xs font-bold text-slate-400 hover:text-slate-600 transition-colors uppercase tracking-widest"
+                        onClick={() => { /* TODO: Google OAuth 연결 */ }}
+                        className="flex h-[52px] w-full items-center justify-center gap-[9px] rounded-[32px] border border-hairline bg-canvas text-[15px] font-medium text-primary transition-colors hover:bg-[#f7f7f5]"
                     >
-                        아직 회원이 아니신가요? 가입하기
+                        <span className="inline-flex h-[18px] w-[18px] items-center justify-center rounded-full bg-soft-stone font-display text-[12px] font-bold text-primary">
+                            G
+                        </span>
+                        Google로 계속하기
                     </button>
+
+                    <div className="mt-[30px] text-center text-[14px] text-[#75758a]">
+                        아직 계정이 없으신가요?{' '}
+                        <button
+                            type="button"
+                            onClick={() => navigate('/auth/signup')}
+                            className="font-medium text-action-blue"
+                        >
+                            회원가입
+                        </button>
+                    </div>
                 </div>
-            </form>
-        </AuthWrapper>
+            </div>
+        </div>
     );
 }

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -20,13 +20,18 @@ export const router = createBrowserRouter([
         element: <Navigate to="/auth/login" replace />,
     },
     {
+        // Login uses its own full-bleed responsive layout (Cohere design system),
+        // so it sits outside the glass AuthLayout shell.
+        path: '/auth/login',
+        element: <LoginPage />,
+    },
+    {
         path: '/auth',
         element: <AuthLayout />,
         children: [
             { path: 'signup', element: <SignupPage /> },
             { path: 'verify', element: <VerifyPage /> },
             { path: 'welcome', element: <WelcomePage /> },
-            { path: 'login', element: <LoginPage /> },
         ]
     },
     {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,7 +5,38 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      // Cohere design-system tokens (from Claude Design "디자인 시스템 구축")
+      colors: {
+        ink: '#212121',
+        primary: '#17171c',
+        'cohere-black': '#000000',
+        'deep-green': '#003c33',
+        'dark-navy': '#071829',
+        canvas: '#ffffff',
+        'soft-stone': '#eeece7',
+        'pale-green': '#edfce9',
+        'pale-blue': '#f1f5ff',
+        hairline: '#d9d9dd',
+        muted: '#93939f',
+        'action-blue': '#1863dc',
+        'focus-blue': '#4c6ee6',
+        coral: '#ff7759',
+        'coral-soft': '#ffad9b',
+        'form-focus': '#9b60aa',
+        'brand-error': '#b30000',
+      },
+      fontFamily: {
+        // Display headlines/wordmark. Mono eyebrows/labels. Pretendard for KR body.
+        display: ['"Space Grotesk"', '"Pretendard"', 'Inter', 'ui-sans-serif', 'sans-serif'],
+        mono: ['"Space Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+        pretendard: ['"Pretendard"', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
+      letterSpacing: {
+        tightest: '-0.03em',
+        'mono-label': '0.7px',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## 개요

Claude Design 디자인 시스템(Cohere 스타일 에디토리얼 UI)을 기준으로 로그인 화면을 재구현했습니다. 기존 글래스모피즘 스타일을 디자인 시스템 톤에 맞는 중앙 정렬 단일 컬럼 레이아웃으로 교체하고, 웹/모바일 반응형을 적용했습니다.

## 변경 사항

- **레이아웃**: 중앙 정렬 단일 컬럼 (max-width 400px), 웹·모바일 반응형
- **구성**: 좌상단 로고(딥그린 `#003c33`) / 코랄 `LOGIN` eyebrow / "다시 오셨어요" 헤드라인 / 이메일·비밀번호 입력 / 검정 pill 로그인 버튼 / "또는" 구분선 + Google 버튼 / 회원가입 링크
- **폰트**: Space Grotesk(display), Space Mono(mono label), Pretendard(KR body) 로드
- **디자인 토큰**: 컬러·폰트·tracking을 `tailwind.config.js`에 추가
- **라우팅**: 로그인을 전체화면 전용 라우트로 분리 (글래스 `AuthLayout` 밖으로)

## 변경 파일

| 파일 | 설명 |
|------|------|
| `frontend/src/features/auth/pages/LoginPage.tsx` | 로그인 UI 재구현 |
| `frontend/index.html` | 폰트 로드 |
| `frontend/tailwind.config.js` | 디자인 토큰 추가 |
| `frontend/src/router/index.tsx` | 로그인 전용 라우트 분리 |

## API 연동

- ✅ 이메일/비밀번호 로그인(`POST /api/auth/login`) **연동 유지**
- ✅ 이메일 미인증 분기(`EMAIL_VERIFICATION_REQUIRED` → `/auth/verify`) 유지
- ✅ 401 토큰 리프레시 인터셉터 그대로 동작

## 참고 / 후속

- "비밀번호 찾기", "Google 로그인" 버튼은 대응 백엔드가 없어 **UI(placeholder)만** 포함 (클릭 시 동작 없음)
- 워드마크는 디자인 mock의 `tracer`로 표기 — 실제 브랜드명으로 교체 필요 시 `LoginPage.tsx`의 `BRAND` 상수 수정
- signup/onboarding 화면도 동일 디자인 적용 가능 (후속 작업)

## 검증

- `vite build` 통과
- `tsc`: 변경 파일 오류 없음 (기존 무관 경고 별개)

Closes #75