### PR TITLE
feat(frontend): 회원가입/이메일 인증 화면 디자인 시스템 적용

### DIFF
--- a/frontend/src/features/auth/pages/SignupPage.tsx
+++ b/frontend/src/features/auth/pages/SignupPage.tsx
@@ -1,117 +1,201 @@
+import { useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Mail, Lock, User as UserIcon } from 'lucide-react';
+import { Check, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { AuthWrapper } from '@/components/ui/AuthWrapper';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { cn } from '@/utils/cn';
 import { useJoin } from '../hooks/useJoin';
 import { useAuthStore } from '@/stores/authStore';
 
+// Brand wordmark shown top-left. (Design mock uses "tracer" — swap to your brand.)
+const BRAND = 'tracer';
+
 const signupSchema = z.object({
-    email: z.string().email('유효한 이메일 주소를 입력해주세요'),
-    password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
-    name: z.string().min(2, '이름은 2자 이상이어야 합니다'),
+    name: z.string().min(2, '이름은 2자 이상이어야 합니다.'),
+    email: z.string().min(1, '이메일을 입력해주세요.').email('올바른 이메일 형식이 아닙니다.'),
+    password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
+    agree: z.literal(true, { message: '약관에 동의해주세요.' }),
 });
 
 type SignupFormValues = z.infer<typeof signupSchema>;
+
+// Exact field styling from the Claude Design auth screens.
+const inputClass =
+    'w-full h-[50px] border border-hairline rounded-[4px] px-3.5 text-[16px] text-ink ' +
+    'placeholder:text-muted outline-none transition-colors focus:border-form-focus';
 
 export function SignupPage() {
     const navigate = useNavigate();
     const setPendingEmail = useAuthStore((state) => state.setPendingEmail);
     const { mutate: join, isPending, error } = useJoin();
 
+    const screenRef = useRef<HTMLDivElement>(null);
+
     const {
         register,
         handleSubmit,
+        watch,
         formState: { errors },
     } = useForm<SignupFormValues>({
         resolver: zodResolver(signupSchema),
+        defaultValues: { name: '', email: '', password: '', agree: false as unknown as true },
     });
 
+    const agreed = watch('agree');
+
+    // Matches the design's `scrFade` screen entrance.
+    useGSAP(() => {
+        gsap.fromTo(
+            screenRef.current,
+            { opacity: 0, y: 8 },
+            { opacity: 1, y: 0, duration: 0.3, ease: 'power2.out' }
+        );
+    }, []);
+
     const onSubmit = (data: SignupFormValues) => {
-        join(data, {
-            onSuccess: () => {
-                setPendingEmail(data.email);
-                navigate('/auth/verify');
-            },
-        });
+        join(
+            { name: data.name, email: data.email, password: data.password },
+            {
+                onSuccess: () => {
+                    setPendingEmail(data.email);
+                    navigate('/auth/verify');
+                },
+            }
+        );
     };
 
-    const apiError = error as { response?: { status?: number, data?: { message?: string } } };
+    const apiError = error as { response?: { status?: number; data?: { message?: string } } };
     const isConflict = apiError?.response?.status === 409;
     const errorMessage = apiError?.response?.data?.message || error?.message;
 
     return (
-        <AuthWrapper
-            title="Create Account"
-            subtitle="TechStack의 새로운 소식을 가장 먼저 확인하세요."
-        >
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-                <div className="space-y-1">
-                    <div className="relative group">
-                        <Mail className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
-                        <input
-                            {...register('email')}
-                            type="email"
-                            placeholder="이메일 주소"
-                            className="w-full bg-white/40 border border-white/60 rounded-2xl py-4 pl-12 pr-4 text-sm font-bold focus:ring-4 focus:ring-slate-100 outline-none transition-all"
-                        />
-                    </div>
-                    {errors.email && <p className="text-xs text-rose-500 font-bold px-2">{errors.email.message}</p>}
-                </div>
-
-                <div className="space-y-1">
-                    <div className="relative group">
-                        <UserIcon className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
-                        <input
-                            {...register('name')}
-                            type="text"
-                            placeholder="이름 (닉네임)"
-                            className="w-full bg-white/40 border border-white/60 rounded-2xl py-4 pl-12 pr-4 text-sm font-bold focus:ring-4 focus:ring-slate-100 outline-none transition-all"
-                        />
-                    </div>
-                    {errors.name && <p className="text-xs text-rose-500 font-bold px-2">{errors.name.message}</p>}
-                </div>
-
-                <div className="space-y-1">
-                    <div className="relative group">
-                        <Lock className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
-                        <input
-                            {...register('password')}
-                            type="password"
-                            placeholder="비밀번호"
-                            className="w-full bg-white/40 border border-white/60 rounded-2xl py-4 pl-12 pr-4 text-sm font-bold focus:ring-4 focus:ring-slate-100 outline-none transition-all"
-                        />
-                    </div>
-                    {errors.password && <p className="text-xs text-rose-500 font-bold px-2">{errors.password.message}</p>}
-                </div>
-
-                {error && (
-                    <div className="px-2">
-                        <p className="text-xs text-rose-500 font-bold">
-                            {isConflict ? '이미 존재하는 사용자입니다. 다른 이메일을 사용하거나 로그인해주세요.' : errorMessage || '회원가입에 실패했습니다.'}
-                        </p>
-                    </div>
-                )}
-
+        <div ref={screenRef} className="flex min-h-screen flex-col bg-canvas font-pretendard text-ink">
+            {/* Logo header */}
+            <div className="flex items-center gap-2 px-5 py-6 sm:px-10">
                 <button
-                    type="submit"
-                    disabled={isPending}
-                    className="w-full bg-slate-900 text-white py-4 rounded-2xl font-black text-sm uppercase shadow-xl mt-4 active:scale-95 transition-transform disabled:opacity-50 disabled:active:scale-100"
+                    type="button"
+                    onClick={() => navigate('/')}
+                    className="flex items-center gap-2"
+                    aria-label={BRAND}
                 >
-                    {isPending ? '처리 중...' : '인증 코드 전송하기'}
+                    <span className="h-4 w-4 rounded-[5px] bg-deep-green" />
+                    <span className="font-display text-[21px] font-medium tracking-[-0.4px] text-primary">
+                        {BRAND}
+                    </span>
                 </button>
+            </div>
 
-                <div className="text-center pt-4">
-                    <button
-                        type="button"
-                        onClick={() => navigate('/auth/login')}
-                        className="text-xs font-bold text-slate-400 hover:text-slate-600 transition-colors uppercase tracking-widest"
-                    >
-                        이미 계정이 있으신가요? 로그인
-                    </button>
+            {/* Centered signup card */}
+            <div className="flex flex-1 items-center justify-center px-5 pb-20 pt-4">
+                <div className="w-full max-w-[400px]">
+                    <div className="mb-3 font-mono text-[12px] uppercase tracking-mono-label text-coral">
+                        SIGN UP · 1 / 2
+                    </div>
+                    <h1 className="mb-3 font-display text-[32px] font-medium leading-[1.05] tracking-tightest text-primary sm:text-[34px]">
+                        계정 만들기
+                    </h1>
+                    <p className="mb-8 text-[16px] text-[#616161]">
+                        이메일로 인증코드를 보내 본인 확인을 해요.
+                    </p>
+
+                    <form onSubmit={handleSubmit(onSubmit)} noValidate>
+                        <label htmlFor="name" className="mb-[7px] block text-[13px] text-[#616161]">
+                            이름
+                        </label>
+                        <input
+                            id="name"
+                            type="text"
+                            autoComplete="name"
+                            placeholder="김도현"
+                            {...register('name')}
+                            className={cn(inputClass, 'mb-[18px]', errors.name && 'border-brand-error focus:border-brand-error')}
+                        />
+                        {errors.name && (
+                            <p className="-mt-3 mb-3 text-[13px] text-brand-error">{errors.name.message}</p>
+                        )}
+
+                        <label htmlFor="email" className="mb-[7px] block text-[13px] text-[#616161]">
+                            이메일
+                        </label>
+                        <input
+                            id="email"
+                            type="email"
+                            autoComplete="email"
+                            placeholder="you@example.com"
+                            {...register('email')}
+                            className={cn(inputClass, 'mb-[18px]', errors.email && 'border-brand-error focus:border-brand-error')}
+                        />
+                        {errors.email && (
+                            <p className="-mt-3 mb-3 text-[13px] text-brand-error">{errors.email.message}</p>
+                        )}
+
+                        <label htmlFor="password" className="mb-[7px] block text-[13px] text-[#616161]">
+                            비밀번호
+                        </label>
+                        <input
+                            id="password"
+                            type="password"
+                            autoComplete="new-password"
+                            placeholder="8자 이상"
+                            {...register('password')}
+                            className={cn(inputClass, 'mb-[22px]', errors.password && 'border-brand-error focus:border-brand-error')}
+                        />
+                        {errors.password && (
+                            <p className="-mt-4 mb-3 text-[13px] text-brand-error">{errors.password.message}</p>
+                        )}
+
+                        {/* Required terms agreement */}
+                        <label htmlFor="agree" className="mb-2 flex cursor-pointer items-start gap-2.5">
+                            <input id="agree" type="checkbox" className="sr-only" {...register('agree')} />
+                            <span
+                                aria-hidden
+                                className={cn(
+                                    'mt-px flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-[5px] border transition-colors',
+                                    agreed ? 'border-deep-green bg-deep-green' : 'border-hairline bg-canvas'
+                                )}
+                            >
+                                {agreed && <Check size={11} strokeWidth={3} className="text-canvas" />}
+                            </span>
+                            <span className="text-[13px] leading-[1.45] text-[#616161]">
+                                (필수) 서비스 이용약관 및 개인정보처리방침에 동의합니다.
+                            </span>
+                        </label>
+                        {errors.agree && (
+                            <p className="mb-2 text-[13px] text-brand-error">{errors.agree.message}</p>
+                        )}
+
+                        {error && (
+                            <div className="mb-[18px] mt-2 rounded-[4px] border border-brand-error/20 bg-brand-error/5 px-3.5 py-3 text-[13px] text-brand-error">
+                                {isConflict
+                                    ? '이미 존재하는 사용자입니다. 다른 이메일을 사용하거나 로그인해주세요.'
+                                    : errorMessage || '회원가입에 실패했습니다.'}
+                            </div>
+                        )}
+
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="mt-6 flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black disabled:cursor-not-allowed disabled:opacity-70"
+                        >
+                            {isPending ? <Loader2 className="animate-spin" size={20} /> : '인증코드 받기'}
+                        </button>
+                    </form>
+
+                    <div className="mt-[30px] text-center text-[14px] text-[#75758a]">
+                        이미 계정이 있으신가요?{' '}
+                        <button
+                            type="button"
+                            onClick={() => navigate('/auth/login')}
+                            className="font-medium text-action-blue"
+                        >
+                            로그인
+                        </button>
+                    </div>
                 </div>
-            </form>
-        </AuthWrapper>
+            </div>
+        </div>
     );
 }

--- a/frontend/src/features/auth/pages/VerifyPage.tsx
+++ b/frontend/src/features/auth/pages/VerifyPage.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AuthWrapper } from '@/components/ui/AuthWrapper';
+import { ChevronLeft, Info, AlertCircle } from 'lucide-react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { cn } from '@/utils/cn';
 import { useAuthStore } from '@/stores/authStore';
 import { useConfirmVerification } from '../hooks/useConfirmVerification';
 import { useRequestVerification } from '../hooks/useRequestVerification';
@@ -10,6 +13,7 @@ export function VerifyPage() {
     const pendingEmail = useAuthStore((state) => state.pendingEmail);
     const [code, setCode] = useState(['', '', '', '', '', '']);
     const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+    const screenRef = useRef<HTMLDivElement>(null);
 
     const { mutate: confirm, isPending: isConfirming, error: confirmError } = useConfirmVerification();
     const { mutate: requestResend, isPending: isResending, isSuccess: isResent } = useRequestVerification();
@@ -19,6 +23,15 @@ export function VerifyPage() {
             navigate('/auth/signup', { replace: true });
         }
     }, [pendingEmail, navigate]);
+
+    // Matches the design's `scrFade` screen entrance.
+    useGSAP(() => {
+        gsap.fromTo(
+            screenRef.current,
+            { opacity: 0, y: 8 },
+            { opacity: 1, y: 0, duration: 0.3, ease: 'power2.out' }
+        );
+    }, []);
 
     const handleInput = (index: number, value: string) => {
         if (!/^[0-9A-Za-z]?$/.test(value)) return;
@@ -64,51 +77,92 @@ export function VerifyPage() {
     const errorMessage = apiError?.response?.data?.message || confirmError?.message;
 
     return (
-        <AuthWrapper title="Verify Email" subtitle={pendingEmail ? `${pendingEmail}로 발송된\n6자리 인증 코드를 입력해주세요.` : "인증 코드를 입력해주세요."}>
-            <div className="space-y-6">
-                <div className="flex justify-between gap-2">
-                    {[0, 1, 2, 3, 4, 5].map((index) => (
-                        <input
-                            key={index}
-                            ref={(el) => { inputRefs.current[index] = el; }}
-                            type="text"
-                            maxLength={1}
-                            value={code[index]}
-                            onChange={(e) => handleInput(index, e.target.value)}
-                            onKeyDown={(e) => handleKeyDown(index, e)}
-                            className="w-12 h-14 bg-white/40 border border-white/60 rounded-xl text-center text-xl font-black text-slate-800 focus:ring-4 focus:ring-slate-100 outline-none transition-all uppercase"
-                        />
-                    ))}
-                </div>
-
-                {confirmError && (
-                    <div className="text-center px-2">
-                        <p className="text-xs text-rose-500 font-bold">{errorMessage || '유효하지 않은 인증 코드입니다.'}</p>
-                    </div>
-                )}
-                {isResent && !confirmError && (
-                    <div className="text-center px-2">
-                        <p className="text-xs text-indigo-500 font-bold">인증 코드가 재전송되었습니다.</p>
-                    </div>
-                )}
-
-                <button
-                    onClick={handleConfirm}
-                    disabled={!isCodeComplete || isConfirming}
-                    className="w-full bg-slate-900 text-white py-4 rounded-2xl font-black text-sm uppercase shadow-xl active:scale-95 transition-transform disabled:opacity-50 disabled:active:scale-100"
-                >
-                    {isConfirming ? '확인 중...' : '인증 완료'}
-                </button>
-                <div className="text-center">
+        <div ref={screenRef} className="flex min-h-screen flex-col bg-canvas font-pretendard text-ink">
+            <div className="flex flex-1 flex-col px-5 pb-12 pt-14 sm:px-10">
+                <div className="mx-auto flex w-full max-w-[400px] flex-1 flex-col">
+                    {/* Back to the signup form */}
                     <button
-                        onClick={handleResend}
-                        disabled={isResending}
-                        className="text-xs font-bold text-indigo-500 uppercase tracking-widest disabled:opacity-50"
+                        type="button"
+                        onClick={() => navigate('/auth/signup')}
+                        className="mb-9 inline-flex items-center gap-1.5 self-start text-[14px] text-[#75758a] transition-colors hover:text-primary"
                     >
-                        {isResending ? '발송 중...' : '코드 다시 보내기'}
+                        <ChevronLeft size={16} strokeWidth={1.8} />
+                        이전
                     </button>
+
+                    <div className="mb-3 font-mono text-[12px] uppercase tracking-mono-label text-coral">
+                        SIGN UP · 2 / 2
+                    </div>
+                    <h1 className="mb-3.5 font-display text-[32px] font-medium leading-[1.05] tracking-tightest text-primary sm:text-[34px]">
+                        이메일을 확인해주세요
+                    </h1>
+                    <p className="mb-9 text-[16px] leading-[1.5] text-[#616161]">
+                        <span className="font-semibold text-ink">{pendingEmail}</span>으로
+                        <br />
+                        6자리 인증코드를 보냈어요.
+                    </p>
+
+                    {/* 6-digit code boxes */}
+                    <div className="mb-[18px] flex gap-[9px]">
+                        {[0, 1, 2, 3, 4, 5].map((index) => (
+                            <input
+                                key={index}
+                                ref={(el) => { inputRefs.current[index] = el; }}
+                                type="text"
+                                inputMode="text"
+                                maxLength={1}
+                                value={code[index]}
+                                onChange={(e) => handleInput(index, e.target.value)}
+                                onKeyDown={(e) => handleKeyDown(index, e)}
+                                className={cn(
+                                    'h-[60px] min-w-0 flex-1 rounded-[10px] border-[1.5px] bg-canvas text-center font-display text-[24px] font-semibold uppercase text-primary outline-none transition-colors focus:border-form-focus',
+                                    code[index] ? 'border-ink' : 'border-hairline'
+                                )}
+                            />
+                        ))}
+                    </div>
+
+                    {confirmError && (
+                        <div className="mb-[18px] flex items-center gap-[7px]">
+                            <AlertCircle size={15} className="flex-shrink-0 text-brand-error" />
+                            <span className="text-[13px] text-brand-error">
+                                {errorMessage || '인증코드가 올바르지 않아요. 다시 확인해주세요.'}
+                            </span>
+                        </div>
+                    )}
+
+                    <div className="mb-[30px] text-[14px] text-[#75758a]">
+                        코드를 받지 못하셨나요?{' '}
+                        <button
+                            type="button"
+                            onClick={handleResend}
+                            disabled={isResending}
+                            className={cn(
+                                'font-medium disabled:opacity-60',
+                                isResent && !confirmError ? 'text-deep-green' : 'text-action-blue'
+                            )}
+                        >
+                            {isResending ? '발송 중...' : isResent && !confirmError ? '재전송 완료' : '코드 다시 보내기'}
+                        </button>
+                    </div>
+
+                    <button
+                        type="button"
+                        onClick={handleConfirm}
+                        disabled={!isCodeComplete || isConfirming}
+                        className="flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black disabled:cursor-not-allowed disabled:opacity-70"
+                    >
+                        {isConfirming ? '확인 중...' : '인증하고 가입 완료'}
+                    </button>
+
+                    <div className="mt-[22px] flex items-start gap-2 px-0.5">
+                        <Info size={14} className="mt-0.5 flex-shrink-0 text-muted" strokeWidth={1.8} />
+                        <p className="text-[12px] leading-[1.6] text-muted">
+                            인증코드는 보통 1~2분 내에 도착해요. 메일이 보이지 않으면 스팸함도 확인해주세요.
+                        </p>
+                    </div>
                 </div>
             </div>
-        </AuthWrapper>
+        </div>
     );
 }

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -20,17 +20,23 @@ export const router = createBrowserRouter([
         element: <Navigate to="/auth/login" replace />,
     },
     {
-        // Login uses its own full-bleed responsive layout (Cohere design system),
-        // so it sits outside the glass AuthLayout shell.
+        // Login, signup and the verify step use their own full-bleed responsive
+        // layout (Cohere design system), so they sit outside the glass AuthLayout shell.
         path: '/auth/login',
         element: <LoginPage />,
+    },
+    {
+        path: '/auth/signup',
+        element: <SignupPage />,
+    },
+    {
+        path: '/auth/verify',
+        element: <VerifyPage />,
     },
     {
         path: '/auth',
         element: <AuthLayout />,
         children: [
-            { path: 'signup', element: <SignupPage /> },
-            { path: 'verify', element: <VerifyPage /> },
             { path: 'welcome', element: <WelcomePage /> },
         ]
     },


### PR DESCRIPTION
## 개요

Claude Design 디자인 시스템(Cohere 스타일 에디토리얼 UI)을 기준으로 회원가입 플로우를 재구현했습니다. 기존 글래스모피즘 스타일을 디자인 시스템 톤에 맞는 중앙 정렬 단일 컬럼 레이아웃으로 교체하고, 회원가입 → 이메일 인증 2단계 화면을 전체화면 전용 라우트로 분리했습니다. 앞서 적용한 로그인 화면(#76)과 동일 톤으로 통일합니다.

## 변경 사항

### STEP 1 — 회원가입 폼 (`/auth/signup`)
- 좌상단 로고(딥그린 `#003c33`) + 코랄 `SIGN UP · 1 / 2` eyebrow
- "계정 만들기" 헤드라인 / "이메일로 인증코드를 보내 본인 확인을 해요." 부제
- 이름·이메일·비밀번호 입력 (radius 4px, 포커스 보더 `#9b60aa`)
- (필수) 서비스 이용약관·개인정보처리방침 동의 체크박스
- 검정 pill "인증코드 받기" 버튼 / 하단 로그인 링크

### STEP 2 — 이메일 인증 코드 (`/auth/verify`)
- "이전" 뒤로 버튼(가입 폼으로) + `SIGN UP · 2 / 2` eyebrow
- "이메일을 확인해주세요" 헤드라인 / 발송 이메일 강조
- 6자리 코드 입력 박스 (60px, Space Grotesk, radius 10px, 입력 시 보더 강조)
- 코드 오류 안내 / 재전송 링크 / "인증하고 가입 완료" 버튼 / 안내문

### 라우팅
- 회원가입·인증 화면을 전체화면 전용 라우트로 분리 (글래스 `AuthLayout` 밖으로)

## 변경 파일

| 파일 | 설명 |
|------|------|
| `frontend/src/features/auth/pages/SignupPage.tsx` | 회원가입 폼 UI 재구현 (STEP 1) |
| `frontend/src/features/auth/pages/VerifyPage.tsx` | 이메일 인증 코드 UI 재구현 (STEP 2) |
| `frontend/src/router/index.tsx` | 회원가입·인증 전용 라우트 분리 |

## API 연동

- ✅ 회원가입(`POST /api/auth/join`) **연동 유지** — `useJoin` 그대로, 성공 시 `/auth/verify` 이동
- ✅ 인증 코드 확인/재전송 **연동 유지** — `useConfirmVerification` / `useRequestVerification` 그대로
- ✅ 가입 → 인증 → 환영(`/auth/welcome`) 플로우, `pendingEmail` 가드 동일
- ✅ 409 중복 가입 처리, 코드 입력 자동 포커스/백스페이스 이동 로직 그대로
- ℹ️ 약관 동의 체크박스는 **폼 검증 용도**이며 API 페이로드에는 미포함 (email/password/name만 전송)

## 참고

- 디자인 토큰(컬러/폰트)·폰트 로드는 로그인 작업(#76)에서 이미 추가되어 재사용 (본 PR은 화면·라우팅만 변경)
- 워드마크는 디자인 mock의 `tracer`로 표기 — 실제 브랜드명 교체 시 각 페이지 `BRAND` 상수 수정
- 가입 완료 후 환영 화면(`/auth/welcome`)은 본 PR 범위 밖 (후속 동일 디자인 적용 가능)

## 검증

- `tsc`: 변경 파일 오류 없음 (기존 무관 경고 별개)
- Vite dev 서버 HMR로 두 화면 동작 확인

Closes #77
