### PR TITLE
feat: 메인 페이지 피드 화면 디자인 시스템 적용

### DIFF
--- a/frontend/src/components/ui/TabButton.tsx
+++ b/frontend/src/components/ui/TabButton.tsx
@@ -13,30 +13,12 @@ export function TabButton({ active, icon, label, onClick }: TabButtonProps) {
         <button
             onClick={onClick}
             className={cn(
-                "flex flex-col items-center gap-1 transition-all relative",
-                active ? "text-slate-900" : "text-slate-400"
+                'flex flex-1 flex-col items-center gap-1 py-1 transition-colors',
+                active ? 'text-primary' : 'text-muted'
             )}
         >
-            <div
-                className="relative z-10 active:-translate-y-1 active:scale-[1.15] transition-transform"
-            >
-                {icon}
-            </div>
-
-            <span
-                className={cn(
-                    "text-[7px] font-black uppercase tracking-widest",
-                    active ? "text-slate-900" : "text-slate-400"
-                )}
-            >
-                {label}
-            </span>
-
-            {active && (
-                <div
-                    className="absolute -top-1 -left-2 -right-2 -bottom-1 bg-white/70 blur-xl rounded-full -z-10 animate-in fade-in duration-300"
-                />
-            )}
+            <span className="transition-transform active:scale-110">{icon}</span>
+            <span className="font-mono text-[10px] tracking-[0.3px]">{label}</span>
         </button>
     );
 }

--- a/frontend/src/features/feed/components/FeaturedPostCard.tsx
+++ b/frontend/src/features/feed/components/FeaturedPostCard.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { Bookmark, FolderOpen } from 'lucide-react';
+import type { Post } from '@/types';
+import { cn } from '@/utils/cn';
+import { formatRelativeTime } from '@/utils/time';
+import { useBookmarkToggle } from '../hooks/useBookmarkToggle';
+import { FolderChangeOverlay } from './FolderChangeOverlay';
+
+interface FeaturedPostCardProps {
+    post: Post;
+    onClick: (post: Post) => void;
+}
+
+/** Hero treatment for the top item of the feed — deep-green band over a white body. */
+export function FeaturedPostCard({ post, onClick }: FeaturedPostCardProps) {
+    const { saved, toggle } = useBookmarkToggle(post);
+    const [isFolderOverlayOpen, setIsFolderOverlayOpen] = useState(false);
+
+    return (
+        <article
+            onClick={() => onClick(post)}
+            className="mb-6 cursor-pointer overflow-hidden rounded-[22px] border border-card-border"
+        >
+            <div className="bg-deep-green px-5 pb-[22px] pt-5">
+                <div className="mb-[42px] flex items-center justify-between gap-3">
+                    <span className="truncate font-mono text-[11px] tracking-[0.5px] text-coral-soft">
+                        {post.company}
+                    </span>
+                    <div className="flex shrink-0 items-center gap-1">
+                        {saved && (
+                            <button
+                                type="button"
+                                aria-label="폴더 변경"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    setIsFolderOverlayOpen(true);
+                                }}
+                                className="flex h-7 w-7 items-center justify-center rounded-full text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+                            >
+                                <FolderOpen size={15} strokeWidth={1.8} />
+                            </button>
+                        )}
+                        <button
+                            type="button"
+                            aria-label={saved ? '북마크 해제' : '북마크'}
+                            onClick={toggle}
+                            className={cn(
+                                'flex h-7 w-7 items-center justify-center rounded-full transition-colors',
+                                saved ? 'text-coral' : 'text-white/70 hover:bg-white/10 hover:text-white'
+                            )}
+                        >
+                            <Bookmark size={15} strokeWidth={1.8} fill={saved ? 'currentColor' : 'none'} />
+                        </button>
+                    </div>
+                </div>
+                <h2 className="m-0 font-display text-[22px] font-medium leading-[1.22] tracking-[-0.3px] text-white">
+                    {post.title}
+                </h2>
+            </div>
+
+            <div className="px-5 pb-[18px] pt-4">
+                <p className="m-0 mb-3.5 line-clamp-2 text-[14px] leading-[1.55] text-[#616161]">
+                    {post.excerpt}
+                </p>
+                <div className="flex items-center justify-end">
+                    <span className="text-[12px] text-muted">{formatRelativeTime(post.date)}</span>
+                </div>
+            </div>
+
+            {isFolderOverlayOpen && (
+                <FolderChangeOverlay
+                    post={post}
+                    onClose={() => setIsFolderOverlayOpen(false)}
+                />
+            )}
+        </article>
+    );
+}

--- a/frontend/src/features/feed/components/PostCard.tsx
+++ b/frontend/src/features/feed/components/PostCard.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Bookmark, FolderOpen } from 'lucide-react';
 import type { Post } from '@/types';
-import { useCreateBookmark, useDeleteBookmark } from '@/features/saved/api/bookmarkApi';
-import { useQueryClient } from '@tanstack/react-query';
+import { cn } from '@/utils/cn';
+import { formatRelativeTime } from '@/utils/time';
+import { useBookmarkToggle } from '../hooks/useBookmarkToggle';
 import { FolderChangeOverlay } from './FolderChangeOverlay';
 
 interface PostCardProps {
@@ -11,93 +12,61 @@ interface PostCardProps {
 }
 
 export function PostCard({ post, onClick }: PostCardProps) {
-    const queryClient = useQueryClient();
-    const createBookmark = useCreateBookmark();
-    const deleteBookmark = useDeleteBookmark();
-
-    const [localSaved, setLocalSaved] = useState(post.bookmarkId != null);
+    const { saved, toggle } = useBookmarkToggle(post);
     const [isFolderOverlayOpen, setIsFolderOverlayOpen] = useState(false);
 
-    useEffect(() => {
-        setLocalSaved(post.bookmarkId != null);
-    }, [post.bookmarkId]);
-
-    const handleToggleSave = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        
-        if (localSaved) {
-            setLocalSaved(false);
-            if (post.bookmarkId) {
-                deleteBookmark.mutate(post.bookmarkId, {
-                    onSuccess: () => {
-                        queryClient.invalidateQueries({ queryKey: ['feed'] });
-                        queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
-                    },
-                    onError: () => setLocalSaved(true)
-                });
-            }
-        } else {
-            setLocalSaved(true);
-            createBookmark.mutate(String(post.id), {
-                onSuccess: () => {
-                    queryClient.invalidateQueries({ queryKey: ['feed'] });
-                    queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
-                },
-                onError: () => setLocalSaved(false)
-            });
-        }
-    };
-
     return (
-        <div
+        <article
             id={`post-${post.id}`}
             onClick={() => onClick(post)}
-            className={`bg-white/40 backdrop-blur-xl rounded-[24px] border border-white/60 p-4 shadow-sm active:scale-[0.98] transition-all cursor-pointer hover:bg-white/60`}
+            className="group cursor-pointer border-b border-card-border py-[18px]"
         >
-            <div className="flex items-start gap-4">
-                <div className="flex-1">
-                    <div className="flex items-center gap-2 mb-2">
-                        <img src={post.logo} alt="" className="w-5 h-5 object-contain shadow-sm rounded" />
-                        <div className="flex items-center gap-1.5">
-                            <span className="text-[10px] font-black text-slate-400 uppercase tracking-tighter">
-                                {post.company}
-                            </span>
-                        </div>
-                    </div>
-                    <h4 className="text-[14px] font-bold text-slate-800 leading-snug mb-1">
-                        {post.title}
-                    </h4>
-                    <p className="text-[11px] text-slate-500 line-clamp-1 font-medium">
-                        {post.excerpt}
-                    </p>
-                </div>
-                <div className="flex flex-col gap-2 shrink-0">
-                    {localSaved && (
+            <div className="mb-[7px] flex items-center justify-between gap-3">
+                <span className="truncate font-mono text-[11px] tracking-[0.4px] text-slate">
+                    {post.company}
+                </span>
+                <div className="flex shrink-0 items-center gap-1">
+                    <span className="text-[12px] text-muted">{formatRelativeTime(post.date)}</span>
+                    {saved && (
                         <button
+                            type="button"
+                            aria-label="폴더 변경"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 setIsFolderOverlayOpen(true);
                             }}
-                            className="p-2.5 rounded-2xl transition-all border text-slate-500 bg-white border-slate-100 shadow-sm hover:bg-slate-50 active:scale-95"
+                            className="ml-1 flex h-7 w-7 items-center justify-center rounded-full text-muted transition-colors hover:bg-soft-stone hover:text-ink"
                         >
-                            <FolderOpen size={18} strokeWidth={2.5} />
+                            <FolderOpen size={15} strokeWidth={1.8} />
                         </button>
                     )}
                     <button
-                        onClick={handleToggleSave}
-                        className={`p-2.5 rounded-2xl transition-all border active:scale-95 shadow-sm ${localSaved ? 'text-indigo-500 bg-white border-slate-100' : 'text-slate-300 bg-white/50 border-white/40'}`}
+                        type="button"
+                        aria-label={saved ? '북마크 해제' : '북마크'}
+                        onClick={toggle}
+                        className={cn(
+                            'flex h-7 w-7 items-center justify-center rounded-full transition-colors',
+                            saved ? 'text-coral' : 'text-muted hover:bg-soft-stone hover:text-ink'
+                        )}
                     >
-                        <Bookmark size={18} strokeWidth={2.5} fill={localSaved ? "currentColor" : "none"} />
+                        <Bookmark size={15} strokeWidth={1.8} fill={saved ? 'currentColor' : 'none'} />
                     </button>
                 </div>
             </div>
-            
+
+            <h3 className="mb-1.5 text-[17px] font-semibold leading-[1.3] tracking-[-0.2px] text-primary">
+                {post.title}
+            </h3>
+            <p className="line-clamp-2 text-[14px] leading-[1.5] text-[#616161]">
+                {post.excerpt}
+            </p>
+
             {isFolderOverlayOpen && (
-                <FolderChangeOverlay 
-                    post={post} 
-                    onClose={() => setIsFolderOverlayOpen(false)} 
+                <FolderChangeOverlay
+                    post={post}
+                    onClose={() => setIsFolderOverlayOpen(false)}
                 />
             )}
-        </div>
+        </article>
     );
 }

--- a/frontend/src/features/feed/hooks/useBookmarkToggle.ts
+++ b/frontend/src/features/feed/hooks/useBookmarkToggle.ts
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import type { Post } from '@/types';
+import { useCreateBookmark, useDeleteBookmark } from '@/features/saved/api/bookmarkApi';
+
+interface UseBookmarkToggle {
+    saved: boolean;
+    toggle: (e: React.MouseEvent) => void;
+}
+
+/**
+ * Optimistic bookmark toggle shared by the feed cards.
+ * Reverts the local state if the mutation fails.
+ */
+export function useBookmarkToggle(post: Post): UseBookmarkToggle {
+    const queryClient = useQueryClient();
+    const createBookmark = useCreateBookmark();
+    const deleteBookmark = useDeleteBookmark();
+
+    const [saved, setSaved] = useState(post.bookmarkId != null);
+    // Re-sync the optimistic state when the server value for this post changes,
+    // adjusting during render (React's recommended alternative to an effect).
+    const [prevBookmarkId, setPrevBookmarkId] = useState(post.bookmarkId);
+    if (post.bookmarkId !== prevBookmarkId) {
+        setPrevBookmarkId(post.bookmarkId);
+        setSaved(post.bookmarkId != null);
+    }
+
+    const invalidate = () => {
+        queryClient.invalidateQueries({ queryKey: ['feed'] });
+        queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
+    };
+
+    const toggle = (e: React.MouseEvent) => {
+        e.stopPropagation();
+
+        if (saved) {
+            setSaved(false);
+            if (post.bookmarkId) {
+                deleteBookmark.mutate(post.bookmarkId, {
+                    onSuccess: invalidate,
+                    onError: () => setSaved(true),
+                });
+            }
+        } else {
+            setSaved(true);
+            createBookmark.mutate(String(post.id), {
+                onSuccess: invalidate,
+                onError: () => setSaved(false),
+            });
+        }
+    };
+
+    return { saved, toggle };
+}

--- a/frontend/src/features/feed/pages/HomeTab.tsx
+++ b/frontend/src/features/feed/pages/HomeTab.tsx
@@ -1,10 +1,12 @@
-import { PostCard } from '@/features/feed/components/PostCard';
-import type { Post } from '@/types';
 import { useState } from 'react';
-import { PostDetailOverlay } from '@/features/feed/components/PostDetailOverlay';
-import { useFeed } from '../api/feedApi';
-import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { Loader2 } from 'lucide-react';
+import type { Post } from '@/types';
+import { PostCard } from '@/features/feed/components/PostCard';
+import { FeaturedPostCard } from '@/features/feed/components/FeaturedPostCard';
+import { PostDetailOverlay } from '@/features/feed/components/PostDetailOverlay';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import { formatTodayLabel } from '@/utils/time';
+import { useFeed } from '../api/feedApi';
 
 export function HomeTab() {
     const [selectedPost, setSelectedPost] = useState<Post | null>(null);
@@ -16,60 +18,75 @@ export function HomeTab() {
         enabled: hasNextPage && !isFetchingNextPage,
     });
 
-    const handlePostClick = (post: Post) => {
-        setSelectedPost(post);
-    };
-
-    // Flatten pages to a single array of items and map to Post interface
+    // Map the API feed items onto the shared Post shape. Fields the API does not
+    // provide (category, tags, …) are intentionally left empty — the redesigned
+    // feed cards don't render them.
     const posts: Post[] = data?.pages.flatMap((page) =>
         page.content.map((item) => ({
-            id: item.contentId, // Using contentId as id
+            id: item.contentId,
             company: item.sourceName,
-            logo: item.thumbnailUrl || '/favicon.ico', // provide fallback
+            logo: item.thumbnailUrl || '',
             title: item.title,
             excerpt: item.summary,
             date: item.publishedAt,
-            category: 'Tech', // Fallback or derived
-            tags: [], // Fallback
-            color: 'bg-indigo-500', // Fallback
-            readTime: '3 min read', // Fallback
+            category: '',
+            tags: [],
+            color: '',
+            readTime: '',
             originalUrl: item.originalUrl,
             bookmarkId: item.bookmarkId,
         }))
-    ) || [];
+    ) ?? [];
+
+    const [featured, ...rest] = posts;
 
     return (
         <>
-            <div className="px-5 pt-4 pb-24">
+            <div className="px-5 pb-24">
+                {/* Header */}
+                <div className="pb-4 pt-5">
+                    <p className="mb-1 font-mono text-[11px] tracking-[0.6px] text-muted">
+                        오늘의 피드 · {formatTodayLabel()}
+                    </p>
+                    <h1 className="font-display text-[27px] font-medium tracking-[-0.5px] text-primary">
+                        새로 올라온 글
+                    </h1>
+                </div>
+
+                {/* Feed */}
                 {status === 'pending' ? (
-                    <div className="flex justify-center items-center py-10">
-                        <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+                    <div className="flex items-center justify-center py-16">
+                        <Loader2 className="h-6 w-6 animate-spin text-muted" />
                     </div>
                 ) : status === 'error' ? (
-                    <div className="text-center py-10 text-slate-500">
-                        피드를 불러오는 데 실패했습니다.
+                    <div className="py-16 text-center text-[14px] text-muted">
+                        피드를 불러오지 못했어요.
+                    </div>
+                ) : posts.length === 0 ? (
+                    <div className="py-16 text-center text-[14px] text-muted">
+                        아직 새로 올라온 글이 없어요.
                     </div>
                 ) : (
-                    <div className="space-y-4">
-                        {posts.map((post) => (
-                            <PostCard
-                                key={post.id}
-                                post={post}
-                                onClick={handlePostClick}
-                            />
-                        ))}
-                    </div>
+                    <>
+                        <FeaturedPostCard post={featured} onClick={setSelectedPost} />
+
+                        <p className="mb-1.5 font-mono text-[11px] tracking-[0.6px] text-muted">
+                            최신 글
+                        </p>
+                        <div>
+                            {rest.map((post) => (
+                                <PostCard key={post.id} post={post} onClick={setSelectedPost} />
+                            ))}
+                        </div>
+                    </>
                 )}
 
-                {/* Infinite Scroll trigger area */}
-                <div ref={targetRef} className="h-10 mt-4 flex items-center justify-center">
-                    {isFetchingNextPage && (
-                        <Loader2 className="w-5 h-5 animate-spin text-slate-400" />
-                    )}
+                {/* Infinite scroll trigger */}
+                <div ref={targetRef} className="mt-4 flex h-10 items-center justify-center">
+                    {isFetchingNextPage && <Loader2 className="h-5 w-5 animate-spin text-muted" />}
                 </div>
             </div>
 
-            {/* Detail Overlay */}
             {selectedPost && (
                 <PostDetailOverlay
                     post={selectedPost}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate, useOutlet } from 'react-router-dom';
 import { useRef, useEffect } from 'react';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
-import { Terminal, Search, Bell, Home, Compass, Bookmark, User } from 'lucide-react';
+import { Search, Bell, Home, Compass, Bookmark, User } from 'lucide-react';
 import { TabButton } from '@/components/ui/TabButton';
 import { useUiStore } from '@/stores/uiStore';
 
@@ -23,16 +23,12 @@ export function AppLayout() {
     const outlet = useOutlet();
     const activeTab = location.pathname.replace('/', '') || 'home';
 
-    const blob1Ref = useRef<HTMLDivElement>(null);
-    const blob2Ref = useRef<HTMLDivElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
     const mainWrapperRef = useRef<HTMLDivElement>(null);
     const progressBarRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLElement>(null);
 
     useGSAP(() => {
-        gsap.to(blob1Ref.current, { scale: 1.2, x: 50, y: 30, duration: 7.5, repeat: -1, yoyo: true, ease: "sine.inOut" });
-        gsap.to(blob2Ref.current, { scale: 1.3, x: -60, y: -40, duration: 9, repeat: -1, yoyo: true, ease: "sine.inOut" });
         gsap.fromTo(mainWrapperRef.current, { opacity: 0 }, { opacity: 1, duration: 0.4, ease: 'power2.out' });
     }, []);
 
@@ -100,26 +96,15 @@ export function AppLayout() {
     }, [location.pathname, closeNotifications, closeSearch, closeFolderManagement, closeUpgradePlan, closeSourcesManagement, closePaymentMethod, closeSubscriptionManage, closePaymentHistory]);
 
     return (
-        <div className="h-[100dvh] overflow-hidden bg-slate-200 flex justify-center font-sans selection:bg-slate-300">
-            <div className="fixed inset-0 overflow-hidden pointer-events-none">
-                <div
-                    ref={blob1Ref}
-                    className="absolute top-[-15%] left-[-15%] w-[70%] h-[70%] bg-blue-200/20 blur-[120px] rounded-full"
-                />
-                <div
-                    ref={blob2Ref}
-                    className="absolute bottom-[-15%] right-[-15%] w-[70%] h-[70%] bg-slate-100/30 blur-[120px] rounded-full"
-                />
-            </div>
-
-            <div className="w-full max-w-[1200px] flex flex-col md:flex-row md:justify-center relative z-10 w-full">
+        <div className="flex h-[100dvh] justify-center overflow-hidden bg-soft-stone font-pretendard text-ink selection:bg-soft-stone">
+            <div className="relative z-10 flex w-full max-w-[1200px] flex-col md:flex-row md:justify-center">
                 <DesktopSidebar />
-                <div className="w-full max-w-[480px] md:max-w-[540px] lg:max-w-[600px] bg-white/30 backdrop-blur-[60px] h-[100dvh] shadow-[0_20px_50px_rgba(0,0,0,0.1)] flex flex-col relative overflow-hidden border-x border-white/40 shrink-0 mx-auto md:mx-0">
+                <div className="relative mx-auto flex h-[100dvh] w-full max-w-[480px] shrink-0 flex-col overflow-hidden border-x border-card-border bg-canvas md:mx-0 md:max-w-[540px] md:shadow-[0_20px_50px_rgba(0,0,0,0.06)] lg:max-w-[600px]">
                     <div ref={mainWrapperRef} className="flex-1 flex flex-col overflow-hidden relative opacity-0">
 
                         <div
                             ref={progressBarRef}
-                            className="fixed top-0 left-0 right-0 h-1 bg-slate-800/20 origin-left z-[60]"
+                            className="fixed top-0 left-0 right-0 h-0.5 bg-primary/15 origin-left z-[60]"
                             style={{ transform: 'scaleX(0)', maxWidth: 480, margin: '0 auto' }}
                         />
 
@@ -132,28 +117,32 @@ export function AppLayout() {
                         {isSubscriptionMounted && <SubscriptionManageOverlay />}
                         {isPaymentHistoryMounted && <PaymentHistoryOverlay />}
 
-                        <header className="md:hidden sticky top-0 bg-white/40 backdrop-blur-3xl z-40 px-6 pt-5 pb-2 border-b border-white/30">
-                            <div className="flex items-center justify-between mb-1">
-                                <div className="flex items-center gap-2">
-                                    <div className="w-7 h-7 bg-white/60 backdrop-blur-md rounded-lg flex items-center justify-center text-slate-800 shadow-sm border border-white/50">
-                                        <Terminal size={14} strokeWidth={2.5} />
-                                    </div>
-                                    <h1 className="text-base font-black tracking-tighter text-slate-900 uppercase">TechStack</h1>
-                                </div>
+                        <header className="md:hidden sticky top-0 z-40 border-b border-card-border bg-canvas/95 px-5 pb-3 pt-[calc(env(safe-area-inset-top)+18px)] backdrop-blur-xl">
+                            <div className="flex items-center justify-between">
+                                <button
+                                    onClick={() => navigate('/home')}
+                                    className="flex items-center gap-[7px]"
+                                    aria-label="tracer 홈"
+                                >
+                                    <span className="h-[15px] w-[15px] rounded-[4px] bg-deep-green" />
+                                    <span className="font-display text-[20px] font-medium tracking-[-0.3px] text-primary">tracer</span>
+                                </button>
                                 <div className="flex items-center gap-1.5">
                                     <button
                                         onClick={openSearch}
-                                        className="p-2 bg-white/40 backdrop-blur-md rounded-full text-slate-600 border border-white/50 shadow-sm active:scale-90 transition-transform"
+                                        aria-label="검색"
+                                        className="flex h-[38px] w-[38px] items-center justify-center rounded-full text-ink transition-colors hover:bg-soft-stone active:bg-soft-stone"
                                     >
-                                        <Search size={16} />
+                                        <Search size={19} strokeWidth={1.7} />
                                     </button>
                                     <button
                                         onClick={openNotifications}
-                                        className="relative p-2 bg-white/40 backdrop-blur-md rounded-full text-slate-600 border border-white/50 shadow-sm active:scale-90 transition-transform"
+                                        aria-label="알림"
+                                        className="relative flex h-[38px] w-[38px] items-center justify-center rounded-full text-ink transition-colors hover:bg-soft-stone active:bg-soft-stone"
                                     >
-                                        <Bell size={16} />
+                                        <Bell size={19} strokeWidth={1.7} />
                                         {unreadCount > 0 && (
-                                            <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 bg-rose-500 rounded-full border-2 border-white"></span>
+                                            <span className="absolute right-[9px] top-[9px] h-[7px] w-[7px] rounded-full border-[1.5px] border-canvas bg-coral" />
                                         )}
                                     </button>
                                 </div>
@@ -166,11 +155,11 @@ export function AppLayout() {
                             </div>
                         </main>
 
-                        <nav className="md:hidden absolute bottom-0 w-full bg-white/30 backdrop-blur-[40px] border-t border-white/20 px-8 pt-3 pb-4 flex justify-between items-center z-[60]">
-                            <TabButton active={activeTab === 'home' || activeTab === ''} onClick={() => navigate('/home')} icon={<Home size={18} />} label="Home" />
-                            <TabButton active={activeTab === 'explore'} onClick={() => navigate('/explore')} icon={<Compass size={18} />} label="Explore" />
-                            <TabButton active={activeTab === 'saved'} onClick={() => navigate('/saved')} icon={<Bookmark size={18} />} label="Saved" />
-                            <TabButton active={activeTab === 'profile'} onClick={() => navigate('/profile')} icon={<User size={18} />} label="Me" />
+                        <nav className="md:hidden absolute bottom-0 left-0 right-0 z-[60] flex border-t border-card-border bg-canvas/95 px-2 pt-2 pb-[calc(env(safe-area-inset-bottom)+12px)] backdrop-blur-xl">
+                            <TabButton active={activeTab === 'home' || activeTab === ''} onClick={() => navigate('/home')} icon={<Home size={23} strokeWidth={1.6} />} label="홈" />
+                            <TabButton active={activeTab === 'explore'} onClick={() => navigate('/explore')} icon={<Compass size={23} strokeWidth={1.6} />} label="탐색" />
+                            <TabButton active={activeTab === 'saved'} onClick={() => navigate('/saved')} icon={<Bookmark size={23} strokeWidth={1.6} />} label="저장" />
+                            <TabButton active={activeTab === 'profile'} onClick={() => navigate('/profile')} icon={<User size={23} strokeWidth={1.6} />} label="MY" />
                         </nav>
                     </div>
                 </div>

--- a/frontend/src/layouts/DesktopSidebar.tsx
+++ b/frontend/src/layouts/DesktopSidebar.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Terminal, Search, Bell, Home, Compass, Bookmark, User } from 'lucide-react';
+import { Search, Bell, Home, Compass, Bookmark, User } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { useUiStore } from '@/stores/uiStore';
 import { useNotificationStore } from '@/stores/notificationStore';
@@ -17,21 +17,16 @@ function NavItem({ icon, label, isActive, onClick, badgeCount }: NavItemProps) {
         <button
             onClick={onClick}
             className={cn(
-                "w-full flex items-center gap-4 px-4 py-3 rounded-2xl transition-all duration-200 group relative",
+                'group relative flex w-full items-center gap-3 rounded-full px-4 py-2.5 transition-colors',
                 isActive
-                    ? "bg-white shadow-sm text-slate-900 font-bold"
-                    : "text-slate-500 hover:bg-white/50 hover:text-slate-800 font-medium"
+                    ? 'bg-soft-stone text-primary'
+                    : 'text-muted hover:bg-soft-stone/60 hover:text-ink'
             )}
         >
-            <div className={cn(
-                "transition-transform duration-200",
-                isActive ? "scale-110" : "group-hover:scale-110"
-            )}>
-                {icon}
-            </div>
-            <span className="text-[15px]">{label}</span>
+            {icon}
+            <span className={cn('text-[15px]', isActive && 'font-medium')}>{label}</span>
             {badgeCount !== undefined && badgeCount > 0 && (
-                <span className="absolute right-4 w-5 h-5 bg-rose-500 rounded-full flex items-center justify-center text-[10px] text-white font-bold">
+                <span className="absolute right-4 flex h-5 min-w-5 items-center justify-center rounded-full bg-coral px-1 text-[10px] font-medium text-white">
                     {badgeCount > 99 ? '99+' : badgeCount}
                 </span>
             )}
@@ -44,61 +39,61 @@ export function DesktopSidebar() {
     const location = useLocation();
     const activeTab = location.pathname.replace('/', '') || 'home';
 
-    const notifications = useNotificationStore(state => state.notifications);
-    const unreadCount = notifications.filter(n => !n.isRead).length;
+    const notifications = useNotificationStore((state) => state.notifications);
+    const unreadCount = notifications.filter((n) => !n.isRead).length;
 
     const { openSearch, openNotifications } = useUiStore();
 
     return (
-        <div className="hidden md:flex flex-col w-[260px] h-screen sticky top-0 py-8 px-6 overflow-y-auto no-scrollbar shrink-0 z-50">
+        <div className="sticky top-0 z-50 hidden h-screen w-[260px] shrink-0 flex-col overflow-y-auto px-6 py-8 no-scrollbar md:flex">
             {/* Logo */}
-            <div className="flex items-center gap-3 mb-12 px-2 cursor-pointer" onClick={() => navigate('/home')}>
-                <div className="w-10 h-10 bg-white shadow-xl shadow-slate-200/50 rounded-2xl flex items-center justify-center text-indigo-600">
-                    <Terminal size={20} strokeWidth={2.5} />
-                </div>
-                <h1 className="text-xl font-black tracking-tighter text-slate-900 uppercase">
-                    TechStack
-                </h1>
-            </div>
+            <button
+                onClick={() => navigate('/home')}
+                className="mb-12 flex items-center gap-2.5 px-3"
+                aria-label="tracer 홈"
+            >
+                <span className="h-[19px] w-[19px] rounded-[5px] bg-deep-green" />
+                <span className="font-display text-[22px] font-medium tracking-[-0.4px] text-primary">tracer</span>
+            </button>
 
             {/* Navigation */}
-            <nav className="flex flex-col gap-2 mb-8">
+            <nav className="mb-8 flex flex-col gap-1.5">
                 <NavItem
-                    icon={<Home size={22} />}
-                    label="Home"
+                    icon={<Home size={22} strokeWidth={1.7} />}
+                    label="홈"
                     isActive={activeTab === 'home' || activeTab === ''}
                     onClick={() => navigate('/home')}
                 />
                 <NavItem
-                    icon={<Compass size={22} />}
-                    label="Explore"
+                    icon={<Compass size={22} strokeWidth={1.7} />}
+                    label="탐색"
                     isActive={activeTab === 'explore'}
                     onClick={() => navigate('/explore')}
                 />
                 <NavItem
-                    icon={<Bookmark size={22} />}
-                    label="Saved"
+                    icon={<Bookmark size={22} strokeWidth={1.7} />}
+                    label="저장"
                     isActive={activeTab === 'saved'}
                     onClick={() => navigate('/saved')}
                 />
                 <NavItem
-                    icon={<User size={22} />}
-                    label="Profile"
+                    icon={<User size={22} strokeWidth={1.7} />}
+                    label="MY"
                     isActive={activeTab === 'profile'}
                     onClick={() => navigate('/profile')}
                 />
             </nav>
 
             {/* Actions */}
-            <div className="flex flex-col gap-2 mt-auto">
+            <div className="mt-auto flex flex-col gap-1.5">
                 <NavItem
-                    icon={<Search size={22} />}
-                    label="Search"
+                    icon={<Search size={22} strokeWidth={1.7} />}
+                    label="검색"
                     onClick={openSearch}
                 />
                 <NavItem
-                    icon={<Bell size={22} />}
-                    label="Notifications"
+                    icon={<Bell size={22} strokeWidth={1.7} />}
+                    label="알림"
                     onClick={openNotifications}
                     badgeCount={unreadCount}
                 />

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,33 @@
+// Korean date helpers for the feed. The feed API returns naive ISO timestamps
+// (e.g. "2025-03-01T12:00:00"); we treat them as local time.
+
+const WEEKDAYS_KO = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+/** "6월 27일 금" — today's date label for the feed eyebrow. */
+export function formatTodayLabel(date: Date = new Date()): string {
+    return `${date.getMonth() + 1}월 ${date.getDate()}일 ${WEEKDAYS_KO[date.getDay()]}`;
+}
+
+/**
+ * Relative Korean time for a post's publishedAt.
+ * 방금 전 → N분 전 → N시간 전 → 어제 → N일 전 → "M월 D일" for anything older.
+ */
+export function formatRelativeTime(iso: string, now: Date = new Date()): string {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return '';
+
+    const diffMs = now.getTime() - date.getTime();
+    const diffMin = Math.floor(diffMs / 60_000);
+
+    if (diffMin < 1) return '방금 전';
+    if (diffMin < 60) return `${diffMin}분 전`;
+
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) return `${diffHour}시간 전`;
+
+    const diffDay = Math.floor(diffHour / 24);
+    if (diffDay === 1) return '어제';
+    if (diffDay < 7) return `${diffDay}일 전`;
+
+    return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+}


### PR DESCRIPTION
## 개요
메인 페이지(홈 피드) 화면을 `tracer` 디자인 시스템(Cohere 스타일)에 맞춰 재구성했습니다. 로그인/회원가입에 이어 메인 화면을 흰 캔버스 + Space Grotesk 디스플레이 + 모노 라벨 + deep-green/coral 액센트 체계로 통일했습니다.

## 주요 변경
- **HomeTab**: 모노 날짜 eyebrow(`오늘의 피드 · M월 D일`) + `새로 올라온 글` 헤더, featured 카드 + `최신 글` 리스트, 로딩/에러/빈 상태 재디자인
- **FeaturedPostCard**(신규): 첫 글을 deep-green 히어로 카드로 표현
- **PostCard**: hairline 구분선 기반의 깔끔한 리스트 행(소스 · 시간 · 제목 · 2줄 요약)
- **useBookmarkToggle**(신규): 두 카드가 공유하는 낙관적 북마크 토글 훅
- **time.ts**(신규): 한국어 상대시간(방금 전 · N분/시간 전 · 어제 · N일 전) 및 7일 이상은 `YYYY년 M월 D일` 표기, 오늘 날짜 라벨
- **앱 셸**: AppLayout(흰 캔버스, tracer 로고 헤더, 하단 탭바), DesktopSidebar, TabButton을 디자인 시스템으로 재정비

## API 명세에 없어 제외한 디자인 요소
- 카테고리 필터 칩 / 태그 / featured 카테고리 배지 / 신규글 카운트 숫자 (피드 응답에 해당 필드 없음)
- 사용 필드: `sourceName`, `title`, `summary`, `publishedAt`, `bookmarkId`

## 설계 노트
- 디자인의 하단 탭(홈/알림/추천/MY)과 달리 앱의 실제 라우트(홈/탐색/저장/프로필)는 유지하고 **스타일만** 적용 — 내비게이션/라우팅 구조는 변경하지 않음
- 디자인 홈에 없는 북마크/폴더 기능은 기존 기능 보존을 위해 절제된 형태로 유지
- 글 상세(PostDetailOverlay)는 별도 화면이라 이번 범위에서 제외

## 검증
- 변경 파일 ESLint 통과, `vite build` 성공
- (참고) `UpgradePlanOverlay.tsx`의 미사용 import 경고는 origin/main에도 존재하는 기존 문제로 본 PR과 무관
