### PR TITLE
feat: 마이페이지 및 하단바 디자인 시스템 적용

### DIFF
--- a/frontend/src/components/ui/TracerTabBar.tsx
+++ b/frontend/src/components/ui/TracerTabBar.tsx
@@ -1,0 +1,84 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const ACTIVE = '#17171c';
+const INACTIVE = '#93939f';
+
+type TabKey = 'home' | 'explore' | 'saved' | 'profile';
+
+interface Tab {
+    key: TabKey;
+    path: string;
+    label: string;
+    icon: React.ReactNode;
+}
+
+// tracer 디자인 시스템의 하단 탭 아이콘 (23×23, stroke 1.6)
+const TABS: Tab[] = [
+    {
+        key: 'home',
+        path: '/home',
+        label: '홈',
+        icon: (
+            <svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                <path d="M4 11l8-6.5 8 6.5v8a1 1 0 0 1-1 1h-4.5v-6h-5v6H5a1 1 0 0 1-1-1z" strokeLinejoin="round" />
+            </svg>
+        ),
+    },
+    {
+        key: 'explore',
+        path: '/explore',
+        label: '추천',
+        icon: (
+            <svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                <circle cx="12" cy="12" r="8.5" />
+                <path d="M15.5 8.5l-2 5.5-5 2 2-5.5z" fill="currentColor" stroke="none" />
+            </svg>
+        ),
+    },
+    {
+        key: 'saved',
+        path: '/saved',
+        label: '북마크',
+        icon: (
+            <svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                <path d="M6 4h12v16l-6-4-6 4z" strokeLinejoin="round" />
+            </svg>
+        ),
+    },
+    {
+        key: 'profile',
+        path: '/profile',
+        label: 'MY',
+        icon: (
+            <svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+                <circle cx="12" cy="8" r="3.4" />
+                <path d="M5.5 19.5a6.5 6.5 0 0 1 13 0" strokeLinecap="round" />
+            </svg>
+        ),
+    },
+];
+
+export function TracerTabBar() {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const activeTab = location.pathname.replace('/', '') || 'home';
+
+    return (
+        <nav className="md:hidden absolute bottom-0 left-0 right-0 z-[60] flex border-t border-[#f2f2f2] bg-white/[0.92] pb-7 pt-2 backdrop-blur-[14px]">
+            {TABS.map((tab) => {
+                const isActive = activeTab === tab.key || (tab.key === 'home' && activeTab === '');
+                return (
+                    <button
+                        key={tab.key}
+                        onClick={() => navigate(tab.path)}
+                        className="flex flex-1 flex-col items-center gap-1 transition-transform active:scale-95"
+                        style={{ color: isActive ? ACTIVE : INACTIVE }}
+                    >
+                        {tab.icon}
+                        <span className="font-mono text-[10px] tracking-[0.3px]">{tab.label}</span>
+                    </button>
+                );
+            })}
+        </nav>
+    );
+}

--- a/frontend/src/features/profile/api/userApi.ts
+++ b/frontend/src/features/profile/api/userApi.ts
@@ -1,0 +1,35 @@
+import { useMutation } from '@tanstack/react-query';
+import { apiClient } from '@/lib/axios';
+import type { ApiResponse } from '@/types/api.types';
+
+export interface ChangePasswordRequest {
+    currentPassword: string;
+    newPassword: string;
+    confirmPassword: string;
+}
+
+// 비밀번호 변경 — PATCH /api/users/password
+export async function changePassword(body: ChangePasswordRequest): Promise<ApiResponse<null>> {
+    const { data } = await apiClient.patch<ApiResponse<null>>('/api/users/password', body);
+    return data;
+}
+
+export function useChangePassword() {
+    return useMutation({
+        mutationFn: changePassword,
+    });
+}
+
+// 회원 탈퇴 — DELETE /api/users (현재 비밀번호로 본인 확인)
+export async function withdrawUser(password: string): Promise<ApiResponse<null>> {
+    const { data } = await apiClient.delete<ApiResponse<null>>('/api/users', {
+        data: { password },
+    });
+    return data;
+}
+
+export function useWithdrawUser() {
+    return useMutation({
+        mutationFn: withdrawUser,
+    });
+}

--- a/frontend/src/features/profile/pages/PasswordChangeOverlay.tsx
+++ b/frontend/src/features/profile/pages/PasswordChangeOverlay.tsx
@@ -1,0 +1,162 @@
+import { useRef, useEffect, useState } from 'react';
+import { ArrowLeft, Loader2, Check } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { cn } from '@/utils/cn';
+import { useUiStore } from '@/stores/uiStore';
+import { useChangePassword } from '../api/userApi';
+
+// tracer 디자인 시스템(로그인/회원가입 화면)과 동일한 입력 필드 스타일
+const inputClass =
+    'w-full h-[50px] border border-hairline rounded-[4px] px-3.5 text-[16px] text-ink ' +
+    'placeholder:text-muted outline-none transition-colors focus:border-form-focus';
+
+const schema = z
+    .object({
+        currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요.'),
+        newPassword: z
+            .string()
+            .min(8, '비밀번호는 8자 이상이어야 합니다.')
+            .max(20, '비밀번호는 20자 이하여야 합니다.'),
+        confirmPassword: z.string().min(1, '새 비밀번호를 한 번 더 입력해주세요.'),
+    })
+    .refine((v) => v.newPassword === v.confirmPassword, {
+        path: ['confirmPassword'],
+        message: '새 비밀번호가 일치하지 않습니다.',
+    });
+
+type FormValues = z.infer<typeof schema>;
+
+export function PasswordChangeOverlay() {
+    const { isPasswordChangeOpen, closePasswordChange, unmountPasswordChange } = useUiStore();
+    const overlayRef = useRef<HTMLDivElement>(null);
+    const { contextSafe } = useGSAP({ scope: overlayRef });
+
+    const { mutateAsync: changePassword, isPending } = useChangePassword();
+    const [apiError, setApiError] = useState<string | null>(null);
+    const [done, setDone] = useState(false);
+
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<FormValues>({
+        resolver: zodResolver(schema),
+        defaultValues: { currentPassword: '', newPassword: '', confirmPassword: '' },
+    });
+
+    useEffect(() => {
+        contextSafe(() => {
+            if (isPasswordChangeOpen) {
+                gsap.to(overlayRef.current, { x: 0, opacity: 1, duration: 0.4, ease: 'power3.out' });
+            } else {
+                gsap.to(overlayRef.current, {
+                    x: '100%',
+                    opacity: 0,
+                    duration: 0.3,
+                    ease: 'power2.in',
+                    onComplete: unmountPasswordChange,
+                });
+            }
+        })();
+    }, [isPasswordChangeOpen, unmountPasswordChange, contextSafe]);
+
+    const onSubmit = async (data: FormValues) => {
+        setApiError(null);
+        try {
+            await changePassword(data);
+            setDone(true);
+            setTimeout(closePasswordChange, 1100);
+        } catch (error) {
+            const apiErr = error as { response?: { data?: { message?: string } } };
+            setApiError(apiErr?.response?.data?.message || '비밀번호 변경에 실패했습니다. 다시 시도해주세요.');
+        }
+    };
+
+    return (
+        <div
+            ref={overlayRef}
+            className="absolute inset-0 z-[100] flex justify-center overflow-y-auto bg-[#fafafa] font-pretendard translate-x-full opacity-0"
+        >
+            <div className="flex min-h-full w-full max-w-[480px] flex-col">
+                {/* Header */}
+                <div className="sticky top-0 z-10 flex items-center gap-3 bg-[#fafafa]/85 px-5 pb-5 pt-10 backdrop-blur-xl">
+                    <button
+                        onClick={closePasswordChange}
+                        className="rounded-full border border-[#f2f2f2] bg-white p-2 text-ink shadow-sm transition-transform active:scale-90"
+                        aria-label="뒤로"
+                    >
+                        <ArrowLeft size={20} />
+                    </button>
+                    <h2 className="font-display text-[20px] font-medium tracking-tightest text-primary">비밀번호 변경</h2>
+                </div>
+
+                <div className="flex-1 px-5 pb-20 pt-4">
+                    {done ? (
+                        <div className="flex flex-col items-center py-24 text-center">
+                            <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-deep-green text-white">
+                                <Check size={26} strokeWidth={3} />
+                            </div>
+                            <p className="text-[15px] font-medium text-ink">비밀번호가 변경되었습니다.</p>
+                        </div>
+                    ) : (
+                        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+                            <label className="mb-[7px] block text-[13px] text-[#616161]">현재 비밀번호</label>
+                            <input
+                                type="password"
+                                autoComplete="current-password"
+                                placeholder="현재 비밀번호"
+                                {...register('currentPassword')}
+                                className={cn(inputClass, 'mb-2', errors.currentPassword && 'border-brand-error focus:border-brand-error')}
+                            />
+                            {errors.currentPassword && (
+                                <p className="mb-3 text-[13px] text-brand-error">{errors.currentPassword.message}</p>
+                            )}
+
+                            <label className="mb-[7px] mt-4 block text-[13px] text-[#616161]">새 비밀번호</label>
+                            <input
+                                type="password"
+                                autoComplete="new-password"
+                                placeholder="8~20자"
+                                {...register('newPassword')}
+                                className={cn(inputClass, 'mb-2', errors.newPassword && 'border-brand-error focus:border-brand-error')}
+                            />
+                            {errors.newPassword && (
+                                <p className="mb-3 text-[13px] text-brand-error">{errors.newPassword.message}</p>
+                            )}
+
+                            <label className="mb-[7px] mt-4 block text-[13px] text-[#616161]">새 비밀번호 확인</label>
+                            <input
+                                type="password"
+                                autoComplete="new-password"
+                                placeholder="새 비밀번호를 다시 입력"
+                                {...register('confirmPassword')}
+                                className={cn(inputClass, 'mb-2', errors.confirmPassword && 'border-brand-error focus:border-brand-error')}
+                            />
+                            {errors.confirmPassword && (
+                                <p className="mb-3 text-[13px] text-brand-error">{errors.confirmPassword.message}</p>
+                            )}
+
+                            {apiError && (
+                                <div className="mb-4 mt-2 rounded-[4px] border border-brand-error/20 bg-brand-error/5 px-3.5 py-3 text-[13px] text-brand-error">
+                                    {apiError}
+                                </div>
+                            )}
+
+                            <button
+                                type="submit"
+                                disabled={isPending}
+                                className="mt-6 flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black disabled:cursor-not-allowed disabled:opacity-70"
+                            >
+                                {isPending ? <Loader2 className="animate-spin" size={20} /> : '변경하기'}
+                            </button>
+                        </form>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/profile/pages/ProfileTab.tsx
+++ b/frontend/src/features/profile/pages/ProfileTab.tsx
@@ -1,146 +1,160 @@
 import { useNavigate } from 'react-router-dom';
-import { Mail, Bell, ChevronRight, LogOut, UserX, Crown, CreditCard, Link as LinkIcon } from 'lucide-react';
+import { ChevronRight, Crown } from 'lucide-react';
 
 import { useAuthStore } from '@/stores/authStore';
 import { useUiStore } from '@/stores/uiStore';
 import { useMySubscription } from '@/features/payment/api/subscriptionApi';
+import { useMySources } from '../api/sourceApi';
+
+// 마이페이지 행(設定 항목) — 라벨 + (선택) 카운트 + 셰브론
+function SettingRow({
+    label,
+    value,
+    onClick,
+    last = false,
+    danger = false,
+}: {
+    label: string;
+    value?: string;
+    onClick?: () => void;
+    last?: boolean;
+    danger?: boolean;
+}) {
+    return (
+        <button
+            onClick={onClick}
+            className={`flex w-full items-center px-4 py-[15px] text-left transition-colors active:bg-black/[0.02] ${
+                last ? '' : 'border-b border-[#f2f2f2]'
+            }`}
+        >
+            <span className={`flex-1 text-[16px] ${danger ? 'text-brand-error' : 'text-ink'}`}>{label}</span>
+            {value && <span className="mr-2 text-[13px] text-muted">{value}</span>}
+            <ChevronRight size={16} className="text-[#c4c4cc]" />
+        </button>
+    );
+}
+
+// 그룹 라벨 — tracer 모노 캡션
+function GroupLabel({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="mb-[10px] pl-0.5 font-mono text-[11px] uppercase tracking-mono-label text-muted">
+            {children}
+        </div>
+    );
+}
 
 export function ProfileTab() {
     const navigate = useNavigate();
+    const user = useAuthStore((state) => state.user);
     const logout = useAuthStore((state) => state.logout);
+
     const openUpgradePlan = useUiStore((state) => state.openUpgradePlan);
     const openSourcesManagement = useUiStore((state) => state.openSourcesManagement);
     const openPaymentMethod = useUiStore((state) => state.openPaymentMethod);
+    const openPasswordChange = useUiStore((state) => state.openPasswordChange);
+    const openWithdraw = useUiStore((state) => state.openWithdraw);
 
     const { data: subscription } = useMySubscription();
-    const isSubscribed = subscription?.status === 'ACTIVE' || subscription?.status === 'CANCELED' || subscription?.status === 'PAUSED';
+    const isSubscribed =
+        subscription?.status === 'ACTIVE' ||
+        subscription?.status === 'CANCELED' ||
+        subscription?.status === 'PAUSED';
+
+    const { data: mySources } = useMySources();
+    const sourceCount = mySources?.length;
 
     const handleLogout = () => {
         logout();
         navigate('/auth/login');
     };
 
+    const name = user?.name ?? '사용자';
+    const email = user?.email ?? '';
+    const initial = name.trim().charAt(0) || 'U';
+
     return (
-        <div className="px-5 pt-2 pb-24">
-            <div className="bg-white/40 backdrop-blur-xl rounded-[28px] border border-white/60 p-5 shadow-sm mb-6 flex flex-col items-center text-center">
-                <div className="w-16 h-16 bg-gradient-to-tr from-slate-200 to-slate-100 rounded-2xl border-4 border-white shadow-md flex items-center justify-center mb-3 overflow-hidden">
-                    <img
-                        src="https://api.dicebear.com/7.x/avataaars/svg?seed=Felix"
-                        alt="avatar"
-                        className="w-full h-full object-cover"
-                    />
-                </div>
-                <h4 className="text-base font-black text-slate-800 mb-0.5">홍길동</h4>
-                <p className="text-[11px] text-slate-500 font-medium mb-3 flex items-center gap-1 opacity-70">
-                    <Mail size={10} /> developer.hong@example.com
-                </p>
-                <div className="flex gap-1.5">
-                    <div className="px-3 py-1 bg-white/60 rounded-full border border-white/80 text-[8px] font-black text-slate-600 uppercase">
-                        Frontend
-                    </div>
-                    <div className="px-3 py-1 bg-white/60 rounded-full border border-white/80 text-[8px] font-black text-slate-600 uppercase">
-                        React
-                    </div>
-                    {isSubscribed && (
-                        <div className="px-3 py-1 bg-amber-400 rounded-full border border-amber-300 text-[8px] font-black text-white uppercase flex items-center gap-1">
-                            <Crown size={8} strokeWidth={3} /> PRO
-                        </div>
-                    )}
-                </div>
+        <div className="min-h-full bg-[#fafafa] font-pretendard">
+            {/* 헤더 */}
+            <div className="px-5 pb-2 pt-6">
+                <h1 className="font-display text-[30px] font-medium tracking-tightest text-primary">마이페이지</h1>
             </div>
 
-            {!isSubscribed && (
-                <button
-                    onClick={openUpgradePlan}
-                    className="w-full text-left bg-gradient-to-r from-amber-400 to-orange-500 rounded-[28px] p-6 shadow-lg shadow-orange-500/20 mb-8 flex items-center justify-between active:scale-[0.98] transition-transform group overflow-hidden relative border border-orange-400/50"
-                >
-                    <div className="absolute top-0 right-0 w-32 h-32 bg-white/20 rounded-full blur-2xl -translate-y-8 translate-x-8" />
-                    <div className="relative z-10">
-                        <div className="flex items-center gap-1.5 text-white/90 mb-1">
-                            <Crown size={14} strokeWidth={2.5} />
-                            <span className="text-[10px] font-black uppercase tracking-widest">Premium</span>
-                        </div>
-                        <h3 className="text-xl font-black text-white tracking-tight mb-1 group-hover:scale-[1.02] origin-left transition-transform">
-                            UPGRADE TO PRO
-                        </h3>
-                        <p className="text-[11px] text-white/80 font-bold tracking-tight">
-                            무제한 북마크 & 프리미엄 기능
-                        </p>
+            <div className="px-5 pb-28 pt-4">
+                {/* 프로필 */}
+                <div className="mb-7 flex items-center gap-4">
+                    <div className="flex h-[60px] w-[60px] shrink-0 items-center justify-center rounded-full bg-soft-stone font-display text-[22px] font-semibold text-deep-green">
+                        {initial}
                     </div>
-                    <ChevronRight size={24} className="text-white relative z-10 opacity-80 group-hover:opacity-100 group-hover:translate-x-1 transition-all" strokeWidth={2.5} />
-                </button>
-            )}
-
-            <div className="space-y-2">
-                <div className="mb-4">
-                    <h5 className="text-[9px] font-black text-slate-400 uppercase tracking-widest px-2 mb-2">
-                        Preferences
-                    </h5>
+                    <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                            <span className="truncate text-[19px] font-semibold text-ink">{name}</span>
+                            {isSubscribed && (
+                                <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-deep-green px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+                                    <Crown size={9} strokeWidth={3} /> PRO
+                                </span>
+                            )}
+                        </div>
+                        <div className="truncate text-[14px] text-[#75758a]">{email}</div>
+                    </div>
                 </div>
 
-                <button
-                    className="w-full bg-white/40 border border-white/60 rounded-xl p-3.5 flex items-center justify-between active:scale-95 transition-transform"
-                >
-                    <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 bg-white/50 rounded-lg flex items-center justify-center text-indigo-500 shadow-sm border border-white/50">
-                            <Bell size={16} />
+                {/* PRO 업그레이드 (미구독자) */}
+                {!isSubscribed && (
+                    <button
+                        onClick={openUpgradePlan}
+                        className="group relative mb-7 flex w-full items-center justify-between overflow-hidden rounded-[22px] bg-deep-green px-5 py-[18px] text-left transition-transform active:scale-[0.985]"
+                    >
+                        <div className="relative z-10">
+                            <div className="mb-1.5 flex items-center gap-1.5 text-coral-soft">
+                                <Crown size={13} strokeWidth={2.5} />
+                                <span className="font-mono text-[11px] uppercase tracking-mono-label">Premium</span>
+                            </div>
+                            <div className="font-display text-[18px] font-medium tracking-tightest text-white">
+                                PRO로 업그레이드
+                            </div>
+                            <p className="mt-0.5 text-[12px] text-white/70">무제한 북마크 &amp; 프리미엄 기능</p>
                         </div>
-                        <span className="text-xs font-bold text-slate-700">알림 설정</span>
-                    </div>
-                    <ChevronRight size={14} className="text-slate-300" />
-                </button>
+                        <ChevronRight
+                            size={22}
+                            strokeWidth={2}
+                            className="relative z-10 text-white/80 transition-transform group-hover:translate-x-1"
+                        />
+                    </button>
+                )}
 
-                <button
-                    onClick={openSourcesManagement}
-                    className="w-full bg-white/40 border border-white/60 rounded-xl p-3.5 flex items-center justify-between active:scale-95 transition-transform"
-                >
-                    <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 bg-white/50 rounded-lg flex items-center justify-center text-teal-500 shadow-sm border border-white/50">
-                            <LinkIcon size={16} />
-                        </div>
-                        <span className="text-xs font-bold text-slate-700">내 소스 관리</span>
-                    </div>
-                    <ChevronRight size={14} className="text-slate-300" />
-                </button>
-
-                <button
-                    onClick={openPaymentMethod}
-                    className="w-full bg-white/40 border border-white/60 rounded-xl p-3.5 flex items-center justify-between active:scale-95 transition-transform"
-                >
-                    <div className="flex items-center gap-3">
-                        <div className="w-8 h-8 bg-white/50 rounded-lg flex items-center justify-center text-amber-500 shadow-sm border border-white/50">
-                            <CreditCard size={16} />
-                        </div>
-                        <span className="text-xs font-bold text-slate-700">결제 및 구독</span>
-                    </div>
-                    <ChevronRight size={14} className="text-slate-300" />
-                </button>
-
-                <div className="mt-8 mb-4">
-                    <h5 className="text-[9px] font-black text-slate-400 uppercase tracking-widest px-2 mb-2">
-                        Danger Zone
-                    </h5>
+                {/* 콘텐츠 */}
+                <GroupLabel>콘텐츠</GroupLabel>
+                <div className="mb-6 overflow-hidden rounded-2xl border border-[#f2f2f2] bg-white">
+                    <SettingRow
+                        label="팔로잉 블로그"
+                        value={sourceCount !== undefined ? `${sourceCount}개` : undefined}
+                        onClick={openSourcesManagement}
+                    />
+                    <SettingRow label="저장한 글" onClick={() => navigate('/saved')} last />
                 </div>
 
+                {/* 계정 */}
+                <GroupLabel>계정</GroupLabel>
+                <div className="mb-7 overflow-hidden rounded-2xl border border-[#f2f2f2] bg-white">
+                    <SettingRow label="비밀번호 변경" onClick={openPasswordChange} />
+                    <SettingRow label="결제 및 구독" onClick={openPaymentMethod} last />
+                </div>
+
+                {/* 로그아웃 / 회원탈퇴 */}
                 <button
                     onClick={handleLogout}
-                    className="w-full bg-white/40 border border-white/60 rounded-xl p-3.5 flex items-center gap-3 active:scale-95 transition-transform"
+                    className="h-[50px] w-full rounded-[32px] border border-[#e5e7eb] bg-white text-[15px] font-medium text-brand-error transition-colors hover:bg-[#fff5f5]"
                 >
-                    <div className="w-8 h-8 bg-white/50 rounded-lg flex items-center justify-center text-slate-500 shadow-sm border border-white/50">
-                        <LogOut size={16} />
-                    </div>
-                    <span className="text-xs font-bold text-slate-700">로그아웃</span>
+                    로그아웃
                 </button>
-
-                <button
-                    onClick={() => navigate('/auth/signup')}
-                    className="w-full bg-rose-50/20 border border-rose-100/30 rounded-xl p-3.5 flex items-center gap-3 active:scale-95 transition-transform"
-                >
-                    <div className="w-8 h-8 bg-rose-50/50 rounded-lg flex items-center justify-center text-rose-500 shadow-sm border border-rose-100/30">
-                        <UserX size={16} />
-                    </div>
-                    <span className="text-xs font-bold text-rose-600">회원탈퇴</span>
-                </button>
+                <div className="mt-5 text-center">
+                    <button
+                        onClick={openWithdraw}
+                        className="text-[13px] text-muted underline-offset-2 transition-colors hover:text-brand-error hover:underline"
+                    >
+                        회원 탈퇴
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/frontend/src/features/profile/pages/UpgradePlanOverlay.tsx
+++ b/frontend/src/features/profile/pages/UpgradePlanOverlay.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useState } from 'react';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
 import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
-import { ArrowLeft, Bookmark, Folder, Star, Zap, CheckCircle2, Crown, Sparkles, Tag, Loader2 } from 'lucide-react';
+import { ArrowLeft, Bookmark, Folder, CheckCircle2, Crown, Sparkles, Tag, Loader2 } from 'lucide-react';
 import { useUiStore } from '@/stores/uiStore';
 import { getCustomerKey, usePaymentMethods } from '@/features/payment/api/paymentApi';
 import { useStartSubscription } from '@/features/payment/api/subscriptionApi';

--- a/frontend/src/features/profile/pages/WithdrawOverlay.tsx
+++ b/frontend/src/features/profile/pages/WithdrawOverlay.tsx
@@ -1,0 +1,127 @@
+import { useRef, useEffect, useState } from 'react';
+import { ArrowLeft, Loader2, AlertTriangle } from 'lucide-react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { cn } from '@/utils/cn';
+import { useUiStore } from '@/stores/uiStore';
+import { useAuthStore } from '@/stores/authStore';
+import { useWithdrawUser } from '../api/userApi';
+
+const inputClass =
+    'w-full h-[50px] border border-hairline rounded-[4px] px-3.5 text-[16px] text-ink ' +
+    'placeholder:text-muted outline-none transition-colors focus:border-form-focus';
+
+export function WithdrawOverlay() {
+    const { isWithdrawOpen, closeWithdraw, unmountWithdraw } = useUiStore();
+    const logout = useAuthStore((state) => state.logout);
+    const overlayRef = useRef<HTMLDivElement>(null);
+    const { contextSafe } = useGSAP({ scope: overlayRef });
+
+    const { mutateAsync: withdraw, isPending } = useWithdrawUser();
+    const [password, setPassword] = useState('');
+    const [confirmed, setConfirmed] = useState(false);
+    const [apiError, setApiError] = useState<string | null>(null);
+
+    useEffect(() => {
+        contextSafe(() => {
+            if (isWithdrawOpen) {
+                gsap.to(overlayRef.current, { x: 0, opacity: 1, duration: 0.4, ease: 'power3.out' });
+            } else {
+                gsap.to(overlayRef.current, {
+                    x: '100%',
+                    opacity: 0,
+                    duration: 0.3,
+                    ease: 'power2.in',
+                    onComplete: unmountWithdraw,
+                });
+            }
+        })();
+    }, [isWithdrawOpen, unmountWithdraw, contextSafe]);
+
+    const handleWithdraw = async () => {
+        if (!password || !confirmed) return;
+        setApiError(null);
+        try {
+            await withdraw(password);
+            // 탈퇴 성공 → 인증 정보 정리 후 로그인 화면으로 (authStore.logout이 리다이렉트 처리)
+            logout();
+        } catch (error) {
+            const apiErr = error as { response?: { data?: { message?: string } } };
+            setApiError(apiErr?.response?.data?.message || '회원 탈퇴에 실패했습니다. 비밀번호를 확인해주세요.');
+        }
+    };
+
+    return (
+        <div
+            ref={overlayRef}
+            className="absolute inset-0 z-[100] flex justify-center overflow-y-auto bg-[#fafafa] font-pretendard translate-x-full opacity-0"
+        >
+            <div className="flex min-h-full w-full max-w-[480px] flex-col">
+                {/* Header */}
+                <div className="sticky top-0 z-10 flex items-center gap-3 bg-[#fafafa]/85 px-5 pb-5 pt-10 backdrop-blur-xl">
+                    <button
+                        onClick={closeWithdraw}
+                        className="rounded-full border border-[#f2f2f2] bg-white p-2 text-ink shadow-sm transition-transform active:scale-90"
+                        aria-label="뒤로"
+                    >
+                        <ArrowLeft size={20} />
+                    </button>
+                    <h2 className="font-display text-[20px] font-medium tracking-tightest text-primary">회원 탈퇴</h2>
+                </div>
+
+                <div className="flex-1 px-5 pb-20 pt-4">
+                    {/* Warning */}
+                    <div className="mb-7 flex gap-3 rounded-2xl border border-brand-error/15 bg-brand-error/5 p-4">
+                        <AlertTriangle size={20} className="mt-0.5 shrink-0 text-brand-error" />
+                        <div className="text-[13px] leading-relaxed text-[#616161]">
+                            탈퇴 시 저장한 글, 팔로잉한 블로그, 구독 정보 등 모든 데이터가 삭제되며
+                            <span className="font-semibold text-brand-error"> 복구할 수 없습니다.</span>
+                        </div>
+                    </div>
+
+                    <label className="mb-[7px] block text-[13px] text-[#616161]">비밀번호 확인</label>
+                    <input
+                        type="password"
+                        autoComplete="current-password"
+                        placeholder="현재 비밀번호를 입력해주세요"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className={cn(inputClass, 'mb-5')}
+                    />
+
+                    <label className="mb-7 flex cursor-pointer items-start gap-3">
+                        <input
+                            type="checkbox"
+                            checked={confirmed}
+                            onChange={(e) => setConfirmed(e.target.checked)}
+                            className="mt-0.5 h-[18px] w-[18px] shrink-0 accent-brand-error"
+                        />
+                        <span className="text-[13px] leading-relaxed text-[#616161]">
+                            위 내용을 모두 확인했으며, 계정을 영구적으로 삭제하는 것에 동의합니다.
+                        </span>
+                    </label>
+
+                    {apiError && (
+                        <div className="mb-4 rounded-[4px] border border-brand-error/20 bg-brand-error/5 px-3.5 py-3 text-[13px] text-brand-error">
+                            {apiError}
+                        </div>
+                    )}
+
+                    <button
+                        onClick={handleWithdraw}
+                        disabled={isPending || !password || !confirmed}
+                        className="flex h-[52px] w-full items-center justify-center rounded-[32px] bg-brand-error text-[16px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                        {isPending ? <Loader2 className="animate-spin" size={20} /> : '회원 탈퇴하기'}
+                    </button>
+                    <button
+                        onClick={closeWithdraw}
+                        className="mt-3 h-[52px] w-full rounded-[32px] border border-hairline bg-white text-[15px] font-medium text-primary transition-colors hover:bg-[#f7f7f5]"
+                    >
+                        취소
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,9 +1,9 @@
-import { useLocation, useNavigate, useOutlet } from 'react-router-dom';
+import { useLocation, useOutlet } from 'react-router-dom';
 import { useRef, useEffect } from 'react';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
-import { Terminal, Search, Bell, Home, Compass, Bookmark, User } from 'lucide-react';
-import { TabButton } from '@/components/ui/TabButton';
+import { Terminal, Search, Bell } from 'lucide-react';
+import { TracerTabBar } from '@/components/ui/TracerTabBar';
 import { useUiStore } from '@/stores/uiStore';
 
 import { SearchOverlay } from '@/features/search/components/SearchOverlay';
@@ -14,14 +14,14 @@ import { MySourcesOverlay } from '@/features/profile/pages/MySourcesOverlay';
 import { PaymentMethodManageOverlay } from '@/features/payment/pages/PaymentMethodManageOverlay';
 import { SubscriptionManageOverlay } from '@/features/payment/pages/SubscriptionManageOverlay';
 import { PaymentHistoryOverlay } from '@/features/payment/pages/PaymentHistoryOverlay';
+import { PasswordChangeOverlay } from '@/features/profile/pages/PasswordChangeOverlay';
+import { WithdrawOverlay } from '@/features/profile/pages/WithdrawOverlay';
 import { DesktopSidebar } from './DesktopSidebar';
 import { useNotifications, useNotificationSubscription } from '@/features/notifications/api/notificationApi';
 
 export function AppLayout() {
-    const navigate = useNavigate();
     const location = useLocation();
     const outlet = useOutlet();
-    const activeTab = location.pathname.replace('/', '') || 'home';
 
     const blob1Ref = useRef<HTMLDivElement>(null);
     const blob2Ref = useRef<HTMLDivElement>(null);
@@ -85,6 +85,10 @@ export function AppLayout() {
         closeSubscriptionManage,
         isPaymentHistoryMounted,
         closePaymentHistory,
+        isPasswordChangeMounted,
+        closePasswordChange,
+        isWithdrawMounted,
+        closeWithdraw,
     } = useUiStore();
 
     // 탭 이동(라우트 변경) 시 오버레이 창 닫기
@@ -97,7 +101,9 @@ export function AppLayout() {
         closePaymentMethod();
         closeSubscriptionManage();
         closePaymentHistory();
-    }, [location.pathname, closeNotifications, closeSearch, closeFolderManagement, closeUpgradePlan, closeSourcesManagement, closePaymentMethod, closeSubscriptionManage, closePaymentHistory]);
+        closePasswordChange();
+        closeWithdraw();
+    }, [location.pathname, closeNotifications, closeSearch, closeFolderManagement, closeUpgradePlan, closeSourcesManagement, closePaymentMethod, closeSubscriptionManage, closePaymentHistory, closePasswordChange, closeWithdraw]);
 
     return (
         <div className="h-[100dvh] overflow-hidden bg-slate-200 flex justify-center font-sans selection:bg-slate-300">
@@ -131,6 +137,8 @@ export function AppLayout() {
                         {isPaymentMethodMounted && <PaymentMethodManageOverlay />}
                         {isSubscriptionMounted && <SubscriptionManageOverlay />}
                         {isPaymentHistoryMounted && <PaymentHistoryOverlay />}
+                        {isPasswordChangeMounted && <PasswordChangeOverlay />}
+                        {isWithdrawMounted && <WithdrawOverlay />}
 
                         <header className="md:hidden sticky top-0 bg-white/40 backdrop-blur-3xl z-40 px-6 pt-5 pb-2 border-b border-white/30">
                             <div className="flex items-center justify-between mb-1">
@@ -166,12 +174,7 @@ export function AppLayout() {
                             </div>
                         </main>
 
-                        <nav className="md:hidden absolute bottom-0 w-full bg-white/30 backdrop-blur-[40px] border-t border-white/20 px-8 pt-3 pb-4 flex justify-between items-center z-[60]">
-                            <TabButton active={activeTab === 'home' || activeTab === ''} onClick={() => navigate('/home')} icon={<Home size={18} />} label="Home" />
-                            <TabButton active={activeTab === 'explore'} onClick={() => navigate('/explore')} icon={<Compass size={18} />} label="Explore" />
-                            <TabButton active={activeTab === 'saved'} onClick={() => navigate('/saved')} icon={<Bookmark size={18} />} label="Saved" />
-                            <TabButton active={activeTab === 'profile'} onClick={() => navigate('/profile')} icon={<User size={18} />} label="Me" />
-                        </nav>
+                        <TracerTabBar />
                     </div>
                 </div>
             </div>

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -17,6 +17,10 @@ export interface UiState {
     isSubscriptionOpen: boolean;
     isPaymentHistoryMounted: boolean;
     isPaymentHistoryOpen: boolean;
+    isPasswordChangeMounted: boolean;
+    isPasswordChangeOpen: boolean;
+    isWithdrawMounted: boolean;
+    isWithdrawOpen: boolean;
 
     openSearch: () => void;
     closeSearch: () => void;
@@ -49,6 +53,14 @@ export interface UiState {
     openPaymentHistory: () => void;
     closePaymentHistory: () => void;
     unmountPaymentHistory: () => void;
+
+    openPasswordChange: () => void;
+    closePasswordChange: () => void;
+    unmountPasswordChange: () => void;
+
+    openWithdraw: () => void;
+    closeWithdraw: () => void;
+    unmountWithdraw: () => void;
 }
 
 export const useUiStore = create<UiState>((set) => ({
@@ -68,6 +80,10 @@ export const useUiStore = create<UiState>((set) => ({
     isSubscriptionOpen: false,
     isPaymentHistoryMounted: false,
     isPaymentHistoryOpen: false,
+    isPasswordChangeMounted: false,
+    isPasswordChangeOpen: false,
+    isWithdrawMounted: false,
+    isWithdrawOpen: false,
 
     openSearch: () => set({ isSearchMounted: true, isSearchOpen: true }),
     closeSearch: () => set({ isSearchOpen: false }),
@@ -100,4 +116,12 @@ export const useUiStore = create<UiState>((set) => ({
     openPaymentHistory: () => set({ isPaymentHistoryMounted: true, isPaymentHistoryOpen: true }),
     closePaymentHistory: () => set({ isPaymentHistoryOpen: false }),
     unmountPaymentHistory: () => set({ isPaymentHistoryMounted: false }),
+
+    openPasswordChange: () => set({ isPasswordChangeMounted: true, isPasswordChangeOpen: true }),
+    closePasswordChange: () => set({ isPasswordChangeOpen: false }),
+    unmountPasswordChange: () => set({ isPasswordChangeMounted: false }),
+
+    openWithdraw: () => set({ isWithdrawMounted: true, isWithdrawOpen: true }),
+    closeWithdraw: () => set({ isWithdrawOpen: false }),
+    unmountWithdraw: () => set({ isWithdrawMounted: false }),
 }));


### PR DESCRIPTION
## 개요
Claude Design의 `tracer` 시안을 참조해 **마이페이지 화면**과 **하단 탭바**에 디자인 시스템을 적용했습니다.

## 변경 사항
### 마이페이지 (ProfileTab)
- tracer 디자인 시스템(흰 카드 · Space Grotesk · 모노 캡션)으로 재구성
- 프로필(이니셜 아바타/이름/이메일/PRO 배지), PRO 업그레이드 카드
- **콘텐츠** 그룹: 팔로잉 블로그(소스 개수), 저장한 글
- **계정** 그룹: 비밀번호 변경, 결제 및 구독
- 로그아웃 / 회원 탈퇴

### 하단 탭바 (TracerTabBar)
- 디자인 시안대로 교체 — 반투명 흰 배경 + blur, 헤어라인, 커스텀 SVG 아이콘(23×23), Space Mono 라벨
- 탭: 홈 / 추천 / 북마크 / MY

### 신규 기능 구현
- 비밀번호 변경 오버레이 — `PATCH /api/users/password`
- 회원 탈퇴 오버레이 — `DELETE /api/users` (비밀번호 확인 + 동의)

## 디자인에서 제거한 항목 (서비스 미지원)
| 항목 | 사유 |
|------|------|
| 알림 토글 4종 | 알림 설정 API 없음 (목록·SSE 구독만 존재) |
| 통계(팔로잉/저장/읽음) | 읽음 추적·카운트 엔드포인트 없음 |
| 프로필 편집(이름 변경) | 엔드포인트 없음 |
| 고객 지원 | 관련 기능 없음 |
| 관심 주제 관리 | 프론트 화면 없음 (백엔드 `/api/keywords` CRUD는 존재 → 추후 구현 가능) |

## 참고
- 앱 상단 헤더("TechStack")는 아직 기존 글래스모피즘 스타일 (별도 작업 필요)
- 빌드/타입체크 통과 (`tsc -b` + `vite build`)