### PR TITLE
feat: 알림 페이지 tracer 디자인 적용

### DIFF
--- a/frontend/src/features/notifications/components/NotificationOverlay.tsx
+++ b/frontend/src/features/notifications/components/NotificationOverlay.tsx
@@ -11,6 +11,21 @@ import type { Notification } from '@/types';
 
 type Segment = 'all' | 'unread';
 
+/**
+ * 알림 생성 시각(ms)을 구한다. SSE로 실시간 수신한 알림은 createdAt이
+ * 비어 있을 수 있는데(백엔드 푸시 페이로드에 미포함), 이 경우 NaN으로 처리해
+ * "방금 도착 = 지금"으로 간주한다. `new Date(null)`은 1970이 되므로 falsy 검사가 필요하다.
+ */
+function parseCreatedAt(createdAt: string | null | undefined): number {
+    if (!createdAt) return NaN;
+    return new Date(createdAt).getTime();
+}
+
+/** createdAt이 없거나 유효하지 않으면(=방금 수신) "방금 전"으로 표시한다. */
+function timeLabel(createdAt: string): string {
+    return Number.isNaN(parseCreatedAt(createdAt)) ? '방금 전' : formatRelativeTime(createdAt);
+}
+
 /** 알림 생성 시각을 기준으로 오늘 / 이번 주 / 그 이전으로 묶는다. */
 function groupByPeriod(items: Notification[], now: Date) {
     const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
@@ -21,8 +36,8 @@ function groupByPeriod(items: Notification[], now: Date) {
     const earlier: Notification[] = [];
 
     for (const n of items) {
-        const t = new Date(n.createdAt).getTime();
-        if (Number.isNaN(t) || t >= startOfToday) today.push(n);
+        const t = parseCreatedAt(n.createdAt);
+        if (Number.isNaN(t) || t >= startOfToday) today.push(n); // 무효/미수신 시각은 오늘로
         else if (t >= startOfWeek) week.push(n);
         else earlier.push(n);
     }
@@ -152,7 +167,7 @@ export function NotificationOverlay() {
                                                     {n.title}
                                                 </span>
                                                 <span className="shrink-0 text-[12px] text-muted">
-                                                    {formatRelativeTime(n.createdAt)}
+                                                    {timeLabel(n.createdAt)}
                                                 </span>
                                             </div>
                                             <p

--- a/frontend/src/features/notifications/components/NotificationOverlay.tsx
+++ b/frontend/src/features/notifications/components/NotificationOverlay.tsx
@@ -1,17 +1,53 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState, useMemo } from 'react';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
-import { ArrowLeft, BellOff, Briefcase, TrendingUp } from 'lucide-react';
+import { X } from 'lucide-react';
+import { cn } from '@/utils/cn';
+import { formatRelativeTime } from '@/utils/time';
 import { useUiStore } from '@/stores/uiStore';
 import { useNotifications } from '../api/notificationApi';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import type { Notification } from '@/types';
+
+type Segment = 'all' | 'unread';
+
+/** 알림 생성 시각을 기준으로 오늘 / 이번 주 / 그 이전으로 묶는다. */
+function groupByPeriod(items: Notification[], now: Date) {
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const startOfWeek = startOfToday - 6 * 24 * 60 * 60 * 1000; // 오늘 포함 최근 7일
+
+    const today: Notification[] = [];
+    const week: Notification[] = [];
+    const earlier: Notification[] = [];
+
+    for (const n of items) {
+        const t = new Date(n.createdAt).getTime();
+        if (Number.isNaN(t) || t >= startOfToday) today.push(n);
+        else if (t >= startOfWeek) week.push(n);
+        else earlier.push(n);
+    }
+
+    return [
+        { label: '오늘', items: today },
+        { label: '이번 주', items: week },
+        { label: '그 이전', items: earlier },
+    ].filter((g) => g.items.length > 0);
+}
 
 export function NotificationOverlay() {
     const { isNotificationsOpen, closeNotifications, unmountNotifications } = useUiStore();
-    
+    const [segment, setSegment] = useState<Segment>('all');
+
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } = useNotifications();
-    const notifications = data?.pages.flatMap(page => page.content) || [];
-    
+    const notifications = useMemo(() => data?.pages.flatMap((page) => page.content) ?? [], [data]);
+
+    const visible = useMemo(
+        () => (segment === 'unread' ? notifications.filter((n) => !n.isRead) : notifications),
+        [notifications, segment]
+    );
+    const groups = useMemo(() => groupByPeriod(visible, new Date()), [visible]);
+    const hasUnread = useMemo(() => notifications.some((n) => !n.isRead), [notifications]);
+
     const { targetRef } = useIntersectionObserver({
         onIntersect: fetchNextPage,
         enabled: hasNextPage && !isFetchingNextPage,
@@ -23,14 +59,14 @@ export function NotificationOverlay() {
     useEffect(() => {
         contextSafe(() => {
             if (isNotificationsOpen) {
-                gsap.to(overlayRef.current, { y: 0, opacity: 1, duration: 0.4, ease: "power3.out" });
+                gsap.to(overlayRef.current, { y: 0, opacity: 1, duration: 0.4, ease: 'power3.out' });
             } else {
                 gsap.to(overlayRef.current, {
-                    y: "100%",
+                    y: '100%',
                     opacity: 0,
                     duration: 0.3,
-                    ease: "power2.in",
-                    onComplete: unmountNotifications
+                    ease: 'power2.in',
+                    onComplete: unmountNotifications,
                 });
             }
         })();
@@ -39,72 +75,116 @@ export function NotificationOverlay() {
     return (
         <div
             ref={overlayRef}
-            className="absolute inset-0 z-[100] bg-white flex justify-center translate-y-full opacity-0"
+            className="absolute inset-0 z-[100] flex translate-y-full flex-col bg-canvas opacity-0"
         >
-            <div className="w-full max-w-[480px] flex flex-col px-6 pt-10">
-                <div className="flex items-center justify-between mb-8">
-                    <div className="flex items-center gap-3">
-                        <button
-                            onClick={closeNotifications}
-                            className="p-2 bg-slate-50 border border-slate-100 rounded-full text-slate-600 shadow-sm active:scale-90 transition-transform"
-                        >
-                            <ArrowLeft size={20} />
-                        </button>
-                        <h3 className="text-xl font-black text-slate-900 uppercase tracking-tighter">
-                            알림
-                        </h3>
-                    </div>
+            {/* Header */}
+            <div className="px-5 pb-3 pt-[calc(env(safe-area-inset-top)+34px)]">
+                <div className="mb-3 flex items-center justify-between">
+                    <h1 className="font-display text-[30px] font-medium tracking-tightest text-primary">알림</h1>
+                    <button
+                        onClick={closeNotifications}
+                        aria-label="닫기"
+                        className="flex h-[38px] w-[38px] items-center justify-center rounded-full text-ink transition-colors hover:bg-soft-stone active:bg-soft-stone"
+                    >
+                        <X size={20} strokeWidth={1.8} />
+                    </button>
                 </div>
 
-                <div className="flex-1 overflow-y-auto no-scrollbar space-y-3 pb-10">
-                    {isLoading ? (
-                        <div className="flex justify-center py-10">
-                            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-400"></div>
-                        </div>
-                    ) : isError ? (
-                        <div className="text-center py-20 opacity-50">
-                            <p className="text-sm font-bold text-slate-500">알림을 불러오지 못했습니다.</p>
-                        </div>
-                    ) : notifications.length > 0 ? (
-                        <>
-                            {notifications.map((n) => (
-                                <div
-                                    key={n.id}
-                                    className={`p-5 rounded-3xl border transition-all ${!n.isRead ? 'bg-indigo-50/30 border-indigo-100/50' : 'bg-white border-slate-100 shadow-sm'}`}
-                                >
-                                    <div className="flex items-start gap-4">
-                                        <div className={`w-10 h-10 rounded-2xl flex items-center justify-center shrink-0 ${!n.isRead ? 'bg-blue-100 text-blue-600' : 'bg-slate-100 text-slate-500'}`}>
-                                            {!n.isRead ? <TrendingUp size={18} /> : <Briefcase size={18} />}
+                {/* Segment filter */}
+                <div className="flex gap-2">
+                    {([
+                        { key: 'all', label: '전체' },
+                        { key: 'unread', label: '안 읽음' },
+                    ] as const).map((s) => (
+                        <button
+                            key={s.key}
+                            onClick={() => setSegment(s.key)}
+                            className={cn(
+                                'rounded-full border px-4 py-[7px] text-[13px] font-medium transition-colors',
+                                segment === s.key
+                                    ? 'border-primary bg-primary text-white'
+                                    : 'border-hairline bg-canvas text-[#616161] hover:bg-soft-stone'
+                            )}
+                        >
+                            {s.label}
+                            {s.key === 'unread' && hasUnread && (
+                                <span
+                                    className={cn(
+                                        'ml-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle',
+                                        segment === 'unread' ? 'bg-coral-soft' : 'bg-coral'
+                                    )}
+                                />
+                            )}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* Body */}
+            <div className="no-scrollbar flex-1 overflow-y-auto px-5 pb-24 pt-2">
+                {isLoading ? (
+                    <div className="flex justify-center py-16">
+                        <div className="h-7 w-7 animate-spin rounded-full border-2 border-hairline border-t-primary" />
+                    </div>
+                ) : isError ? (
+                    <div className="px-6 py-20 text-center text-muted">
+                        <div className="mb-2 font-mono text-[12px] tracking-[0.5px]">LOAD FAILED</div>
+                        <div className="text-[15px]">알림을 불러오지 못했어요.</div>
+                    </div>
+                ) : groups.length > 0 ? (
+                    <>
+                        {groups.map((group) => (
+                            <div key={group.label}>
+                                <div className="px-0.5 pb-1 pt-3 font-mono text-[11px] tracking-[0.6px] text-muted">
+                                    {group.label}
+                                </div>
+                                {group.items.map((n) => (
+                                    <div
+                                        key={n.id}
+                                        className="flex items-start gap-[11px] border-b border-[#f2f2f2] py-[15px]"
+                                    >
+                                        <div className="flex w-2 shrink-0 justify-center pt-[5px]">
+                                            {!n.isRead && <span className="h-2 w-2 rounded-full bg-coral" />}
                                         </div>
-                                        <div className="flex-1">
-                                            <div className="flex justify-between items-start mb-1">
-                                                <h4 className="text-xs font-black text-slate-800 uppercase tracking-tight">{n.title}</h4>
-                                                <span className="text-[9px] font-bold text-slate-400">{new Date(n.createdAt).toLocaleDateString()}</span>
+                                        <div className="min-w-0 flex-1">
+                                            <div className="mb-1 flex items-center justify-between gap-2">
+                                                <span className="truncate font-mono text-[11px] tracking-[0.4px] text-[#75758a]">
+                                                    {n.title}
+                                                </span>
+                                                <span className="shrink-0 text-[12px] text-muted">
+                                                    {formatRelativeTime(n.createdAt)}
+                                                </span>
                                             </div>
-                                            <p className="text-[13px] text-slate-600 font-medium leading-snug">{n.message}</p>
+                                            <p
+                                                className={cn(
+                                                    'text-[15px] leading-[1.45]',
+                                                    n.isRead ? 'text-muted' : 'text-ink'
+                                                )}
+                                            >
+                                                {n.message}
+                                            </p>
                                         </div>
                                     </div>
-                                </div>
-                            ))}
-                            {hasNextPage && (
-                                <div ref={targetRef} className="py-4 flex justify-center">
-                                    {isFetchingNextPage ? (
-                                        <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-slate-400"></div>
-                                    ) : (
-                                        <div className="h-5"></div>
-                                    )}
-                                </div>
-                            )}
-                        </>
-                    ) : (
-                        <div className="flex flex-col items-center justify-center py-32 opacity-30">
-                            <BellOff size={48} className="mb-4" strokeWidth={1.5} />
-                            <p className="text-[11px] font-black uppercase tracking-widest text-slate-500 text-center">
-                                알림 목록이 비어있습니다
-                            </p>
+                                ))}
+                            </div>
+                        ))}
+
+                        {hasNextPage && (
+                            <div ref={targetRef} className="flex justify-center py-4">
+                                {isFetchingNextPage && (
+                                    <div className="h-5 w-5 animate-spin rounded-full border-2 border-hairline border-t-primary" />
+                                )}
+                            </div>
+                        )}
+                    </>
+                ) : (
+                    <div className="px-6 py-20 text-center text-muted">
+                        <div className="font-mono text-[12px] tracking-[0.5px]">ALL CAUGHT UP</div>
+                        <div className="mt-2 text-[15px]">
+                            {segment === 'unread' ? '읽지 않은 알림이 없어요.' : '알림이 없어요.'}
                         </div>
-                    )}
-                </div>
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## 개요

알림 페이지를 **tracer 디자인 시스템** 기준으로 전면 재구현했습니다. 기존 오버레이는 `slate-*` 임의 색상과 둥근 카드 스타일이라 디자인 토큰과 맞지 않았습니다.

## 적용 화면

<img src="https://raw.githubusercontent.com/honee8583/key-feed-mono/pr-assets/notifications-design/notifications-design.png" width="360" alt="알림 페이지 디자인" />

## 변경 사항

- 헤더: `font-display` "알림" 타이틀 + safe-area 패딩
- **전체 / 안 읽음** 세그먼트 필터 (클라이언트 사이드)
- **오늘 / 이번 주 / 그 이전** 기간별 그룹핑 (`createdAt` 기준, `font-mono` 섹션 라벨)
- 알림 아이템: 안 읽음 `bg-coral` 점, 출처(`font-mono`) + 상대시간 + 본문, 읽은 항목은 `text-muted`로 톤다운
- 빈 상태(`ALL CAUGHT UP`) / 로딩 / 에러 상태 정리
- 디자인 토큰(`primary`, `coral`, `hairline`, `muted`)과 `cn()` 컨벤션 준수
- 기존 무한 스크롤 · SSE 구독 · react-query 로직 유지

## 디자인에서 제거/변경 (백엔드 미지원)

백엔드 알림 API는 **목록 조회 + SSE 구독**만 제공하며 데이터는 `id/title/message/isRead/createdAt`뿐입니다.

- **"모두 읽음" 버튼 제거** — 읽음 처리 API 부재. 헤더 우측은 오버레이 **닫기(X)** 버튼으로 대체 (헤더 벨에서 열리는 슬라이드업 오버레이라 닫기 동작 필요)
- **알림 항목 클릭 동작 제거** — 읽음 API/링크 필드가 없어 비인터랙티브로 렌더링
- **source/text 분리 → title/message 매핑**

## 확인

- `npx tsc -b` 통과
- `npx eslint` 통과
