### PR TITLE
feat: 비밀번호 재설정 페이지 구현

### DIFF
--- a/frontend/src/features/auth/api/auth.ts
+++ b/frontend/src/features/auth/api/auth.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '@/lib/axios';
 import type { ApiResponse } from '@/types/api.types';
-import type { LoginRequest, LoginResponse, JoinRequest, VerificationRequest, VerificationConfirmRequest, VerificationResponse } from '../types/auth.types';
+import type { LoginRequest, LoginResponse, JoinRequest, VerificationRequest, VerificationConfirmRequest, VerificationResponse, PasswordResetRequest, PasswordResetVerifyRequest, PasswordResetConfirmRequest } from '../types/auth.types';
 
 export async function login(data: LoginRequest): Promise<ApiResponse<LoginResponse>> {
     const response = await apiClient.post<ApiResponse<LoginResponse>>('/api/auth/login', data);
@@ -19,5 +19,20 @@ export async function requestVerification(data: VerificationRequest): Promise<Ap
 
 export async function confirmVerification(data: VerificationConfirmRequest): Promise<ApiResponse<VerificationResponse>> {
     const response = await apiClient.post<ApiResponse<VerificationResponse>>('/api/auth/email-verification/confirm', data);
+    return response.data;
+}
+
+export async function requestPasswordReset(data: PasswordResetRequest): Promise<ApiResponse<null>> {
+    const response = await apiClient.post<ApiResponse<null>>('/api/auth/password-reset/request', data);
+    return response.data;
+}
+
+export async function verifyPasswordResetCode(data: PasswordResetVerifyRequest): Promise<ApiResponse<VerificationResponse>> {
+    const response = await apiClient.post<ApiResponse<VerificationResponse>>('/api/auth/password-reset/verify', data);
+    return response.data;
+}
+
+export async function confirmPasswordReset(data: PasswordResetConfirmRequest): Promise<ApiResponse<null>> {
+    const response = await apiClient.post<ApiResponse<null>>('/api/auth/password-reset/confirm', data);
     return response.data;
 }

--- a/frontend/src/features/auth/hooks/useConfirmPasswordReset.ts
+++ b/frontend/src/features/auth/hooks/useConfirmPasswordReset.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { confirmPasswordReset } from '../api/auth';
+import type { PasswordResetConfirmRequest } from '../types/auth.types';
+import type { ApiResponse } from '@/types/api.types';
+
+export function useConfirmPasswordReset() {
+    return useMutation<ApiResponse<null>, Error, PasswordResetConfirmRequest>({
+        mutationFn: (data: PasswordResetConfirmRequest) => confirmPasswordReset(data),
+    });
+}

--- a/frontend/src/features/auth/hooks/useRequestPasswordReset.ts
+++ b/frontend/src/features/auth/hooks/useRequestPasswordReset.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { requestPasswordReset } from '../api/auth';
+import type { PasswordResetRequest } from '../types/auth.types';
+import type { ApiResponse } from '@/types/api.types';
+
+export function useRequestPasswordReset() {
+    return useMutation<ApiResponse<null>, Error, PasswordResetRequest>({
+        mutationFn: (data: PasswordResetRequest) => requestPasswordReset(data),
+    });
+}

--- a/frontend/src/features/auth/hooks/useVerifyPasswordResetCode.ts
+++ b/frontend/src/features/auth/hooks/useVerifyPasswordResetCode.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { verifyPasswordResetCode } from '../api/auth';
+import type { PasswordResetVerifyRequest, VerificationResponse } from '../types/auth.types';
+import type { ApiResponse } from '@/types/api.types';
+
+export function useVerifyPasswordResetCode() {
+    return useMutation<ApiResponse<VerificationResponse>, Error, PasswordResetVerifyRequest>({
+        mutationFn: (data: PasswordResetVerifyRequest) => verifyPasswordResetCode(data),
+    });
+}

--- a/frontend/src/features/auth/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/features/auth/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,401 @@
+import { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronLeft, AlertCircle, Check, Loader2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { cn } from '@/utils/cn';
+import { useRequestPasswordReset } from '../hooks/useRequestPasswordReset';
+import { useVerifyPasswordResetCode } from '../hooks/useVerifyPasswordResetCode';
+import { useConfirmPasswordReset } from '../hooks/useConfirmPasswordReset';
+
+type Step = 'email' | 'verify' | 'reset' | 'done';
+
+// Field styling shared with the login/verify screens (Claude Design tracer).
+const inputClass =
+    'w-full h-[50px] border border-hairline rounded-[4px] px-3.5 text-[16px] text-ink ' +
+    'placeholder:text-muted outline-none transition-colors focus:border-form-focus';
+
+const emailSchema = z.string().email('올바른 이메일 형식이 아닙니다.');
+
+const passwordSchema = z
+    .object({
+        newPassword: z
+            .string()
+            .min(8, '비밀번호는 8자 이상 20자 이하로 입력해주세요.')
+            .max(20, '비밀번호는 8자 이상 20자 이하로 입력해주세요.'),
+        confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+    })
+    .refine((data) => data.newPassword === data.confirmPassword, {
+        message: '비밀번호가 일치하지 않습니다.',
+        path: ['confirmPassword'],
+    });
+
+type PasswordFormValues = z.infer<typeof passwordSchema>;
+
+function getErrorMessage(error: unknown, fallback: string): string {
+    const apiError = error as { response?: { data?: { message?: string } } };
+    return apiError?.response?.data?.message || fallback;
+}
+
+export function ForgotPasswordPage() {
+    const navigate = useNavigate();
+    const screenRef = useRef<HTMLDivElement>(null);
+
+    const [step, setStep] = useState<Step>('email');
+    const [email, setEmail] = useState('');
+    const [emailError, setEmailError] = useState<string | null>(null);
+
+    const [code, setCode] = useState(['', '', '', '', '', '']);
+    const [codeError, setCodeError] = useState<string | null>(null);
+    const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+    const requestReset = useRequestPasswordReset();
+    const verifyCode = useVerifyPasswordResetCode();
+    const confirmReset = useConfirmPasswordReset();
+
+    const {
+        register,
+        handleSubmit,
+        setError: setFormError,
+        formState: { errors },
+    } = useForm<PasswordFormValues>({
+        resolver: zodResolver(passwordSchema),
+        defaultValues: { newPassword: '', confirmPassword: '' },
+    });
+
+    // Re-run the design's `scrFade` entrance on every step change.
+    useGSAP(() => {
+        gsap.fromTo(
+            screenRef.current,
+            { opacity: 0, y: 8 },
+            { opacity: 1, y: 0, duration: 0.3, ease: 'power2.out' }
+        );
+    }, [step]);
+
+    const goLogin = () => navigate('/auth/login');
+
+    // ── STEP 1: request code ──────────────────────────────────────────────
+    const handleSendCode = () => {
+        setEmailError(null);
+        const parsed = emailSchema.safeParse(email);
+        if (!parsed.success) {
+            setEmailError(parsed.error.issues[0].message);
+            return;
+        }
+        requestReset.mutate(
+            { email },
+            {
+                onSuccess: () => {
+                    setCode(['', '', '', '', '', '']);
+                    setStep('verify');
+                },
+                onError: (error) => {
+                    setEmailError(getErrorMessage(error, '가입된 이메일을 찾을 수 없어요.'));
+                },
+            }
+        );
+    };
+
+    // ── STEP 2: verify code ───────────────────────────────────────────────
+    const handleCodeInput = (index: number, value: string) => {
+        if (!/^[0-9]?$/.test(value)) return;
+        const next = [...code];
+        next[index] = value;
+        setCode(next);
+        setCodeError(null);
+        if (value && index < 5) inputRefs.current[index + 1]?.focus();
+    };
+
+    const handleCodeKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Backspace' && !code[index] && index > 0) {
+            inputRefs.current[index - 1]?.focus();
+        }
+    };
+
+    const handleVerify = () => {
+        const fullCode = code.join('');
+        if (fullCode.length < 6) return;
+        setCodeError(null);
+        verifyCode.mutate(
+            { email, code: fullCode },
+            {
+                onSuccess: (response) => {
+                    if (response.data.status === 'VERIFIED') {
+                        setStep('reset');
+                    } else {
+                        setCodeError('인증코드가 올바르지 않아요. 다시 확인해주세요.');
+                    }
+                },
+                onError: (error) => {
+                    setCodeError(getErrorMessage(error, '인증코드가 올바르지 않아요. 다시 확인해주세요.'));
+                },
+            }
+        );
+    };
+
+    const handleResendCode = () => {
+        setCode(['', '', '', '', '', '']);
+        setCodeError(null);
+        inputRefs.current[0]?.focus();
+        requestReset.mutate({ email });
+    };
+
+    // ── STEP 3: set new password ──────────────────────────────────────────
+    const onSubmitNewPassword = (data: PasswordFormValues) => {
+        confirmReset.mutate(
+            { email, newPassword: data.newPassword, confirmPassword: data.confirmPassword },
+            {
+                onSuccess: () => setStep('done'),
+                onError: (error) => {
+                    setFormError('newPassword', {
+                        message: getErrorMessage(error, '비밀번호 변경에 실패했어요. 다시 시도해주세요.'),
+                    });
+                },
+            }
+        );
+    };
+
+    const isCodeComplete = code.every((c) => c !== '');
+    const isResent = requestReset.isSuccess && step === 'verify';
+
+    return (
+        <div ref={screenRef} className="flex min-h-screen flex-col bg-canvas font-pretendard text-ink">
+            <div className="flex flex-1 flex-col px-5 pb-12 pt-14 sm:px-10">
+                <div className="mx-auto flex w-full max-w-[400px] flex-1 flex-col">
+                    {/* ── STEP 1: EMAIL ── */}
+                    {step === 'email' && (
+                        <>
+                            <button
+                                type="button"
+                                onClick={goLogin}
+                                className="mb-9 inline-flex items-center gap-1.5 self-start text-[14px] text-[#75758a] transition-colors hover:text-primary"
+                            >
+                                <ChevronLeft size={16} strokeWidth={1.8} />
+                                로그인
+                            </button>
+
+                            <div className="mb-3 font-mono text-[12px] uppercase tracking-mono-label text-coral">
+                                RESET · 1 / 3
+                            </div>
+                            <h1 className="mb-3.5 font-display text-[32px] font-medium leading-[1.05] tracking-tightest text-primary sm:text-[34px]">
+                                비밀번호 재설정
+                            </h1>
+                            <p className="mb-9 text-[16px] leading-[1.5] text-[#616161]">
+                                가입하신 이메일을 입력하면
+                                <br />
+                                인증코드를 보내드려요.
+                            </p>
+
+                            <label htmlFor="reset-email" className="mb-[7px] block text-[13px] text-[#616161]">
+                                이메일
+                            </label>
+                            <input
+                                id="reset-email"
+                                type="email"
+                                autoComplete="email"
+                                placeholder="you@example.com"
+                                value={email}
+                                onChange={(e) => {
+                                    setEmail(e.target.value);
+                                    setEmailError(null);
+                                }}
+                                onKeyDown={(e) => e.key === 'Enter' && handleSendCode()}
+                                className={cn(inputClass, 'mb-2', emailError && 'border-brand-error focus:border-brand-error')}
+                            />
+                            {emailError && (
+                                <p className="mb-3 flex items-center gap-[7px] text-[13px] text-brand-error">
+                                    <AlertCircle size={15} className="flex-shrink-0" />
+                                    {emailError}
+                                </p>
+                            )}
+
+                            <button
+                                type="button"
+                                onClick={handleSendCode}
+                                disabled={requestReset.isPending}
+                                className="mt-6 flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black disabled:cursor-not-allowed disabled:opacity-70"
+                            >
+                                {requestReset.isPending ? <Loader2 className="animate-spin" size={20} /> : '인증코드 받기'}
+                            </button>
+
+                            <div className="mt-auto pt-8 text-center text-[14px] text-[#75758a]">
+                                비밀번호가 기억나셨나요?{' '}
+                                <button type="button" onClick={goLogin} className="font-medium text-action-blue">
+                                    로그인
+                                </button>
+                            </div>
+                        </>
+                    )}
+
+                    {/* ── STEP 2: VERIFY ── */}
+                    {step === 'verify' && (
+                        <>
+                            <button
+                                type="button"
+                                onClick={() => setStep('email')}
+                                className="mb-9 inline-flex items-center gap-1.5 self-start text-[14px] text-[#75758a] transition-colors hover:text-primary"
+                            >
+                                <ChevronLeft size={16} strokeWidth={1.8} />
+                                이전
+                            </button>
+
+                            <div className="mb-3 font-mono text-[12px] uppercase tracking-mono-label text-coral">
+                                RESET · 2 / 3
+                            </div>
+                            <h1 className="mb-3.5 font-display text-[32px] font-medium leading-[1.05] tracking-tightest text-primary sm:text-[34px]">
+                                이메일을 확인해주세요
+                            </h1>
+                            <p className="mb-9 text-[16px] leading-[1.5] text-[#616161]">
+                                <span className="font-semibold text-ink">{email}</span>으로
+                                <br />
+                                6자리 인증코드를 보냈어요.
+                            </p>
+
+                            <div className="mb-[18px] flex gap-[9px]">
+                                {[0, 1, 2, 3, 4, 5].map((index) => (
+                                    <input
+                                        key={index}
+                                        ref={(el) => { inputRefs.current[index] = el; }}
+                                        type="text"
+                                        inputMode="numeric"
+                                        maxLength={1}
+                                        value={code[index]}
+                                        onChange={(e) => handleCodeInput(index, e.target.value)}
+                                        onKeyDown={(e) => handleCodeKeyDown(index, e)}
+                                        className={cn(
+                                            'h-[60px] min-w-0 flex-1 rounded-[10px] border-[1.5px] bg-canvas text-center font-display text-[24px] font-semibold text-primary outline-none transition-colors focus:border-form-focus',
+                                            codeError ? 'border-brand-error' : code[index] ? 'border-ink' : 'border-hairline'
+                                        )}
+                                    />
+                                ))}
+                            </div>
+
+                            {codeError && (
+                                <div className="mb-[18px] flex items-center gap-[7px]">
+                                    <AlertCircle size={15} className="flex-shrink-0 text-brand-error" />
+                                    <span className="text-[13px] text-brand-error">{codeError}</span>
+                                </div>
+                            )}
+
+                            <div className="mb-[30px] text-[14px] text-[#75758a]">
+                                코드를 받지 못하셨나요?{' '}
+                                <button
+                                    type="button"
+                                    onClick={handleResendCode}
+                                    disabled={requestReset.isPending}
+                                    className={cn(
+                                        'font-medium disabled:opacity-60',
+                                        isResent && !codeError ? 'text-deep-green' : 'text-action-blue'
+                                    )}
+                                >
+                                    {requestReset.isPending ? '발송 중...' : isResent && !codeError ? '재전송 완료' : '코드 다시 보내기'}
+                                </button>
+                            </div>
+
+                            <button
+                                type="button"
+                                onClick={handleVerify}
+                                disabled={!isCodeComplete || verifyCode.isPending}
+                                className="flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black disabled:cursor-not-allowed disabled:opacity-70"
+                            >
+                                {verifyCode.isPending ? <Loader2 className="animate-spin" size={20} /> : '다음'}
+                            </button>
+                        </>
+                    )}
+
+                    {/* ── STEP 3: NEW PASSWORD ── */}
+                    {step === 'reset' && (
+                        <>
+                            <button
+                                type="button"
+                                onClick={() => setStep('verify')}
+                                className="mb-9 inline-flex items-center gap-1.5 self-start text-[14px] text-[#75758a] transition-colors hover:text-primary"
+                            >
+                                <ChevronLeft size={16} strokeWidth={1.8} />
+                                이전
+                            </button>
+
+                            <div className="mb-3 font-mono text-[12px] uppercase tracking-mono-label text-coral">
+                                RESET · 3 / 3
+                            </div>
+                            <h1 className="mb-3.5 font-display text-[32px] font-medium leading-[1.05] tracking-tightest text-primary sm:text-[34px]">
+                                새 비밀번호 설정
+                            </h1>
+                            <p className="mb-9 text-[16px] leading-[1.5] text-[#616161]">
+                                새로 사용할 비밀번호를 입력해주세요.
+                            </p>
+
+                            <form onSubmit={handleSubmit(onSubmitNewPassword)} noValidate>
+                                <label htmlFor="new-password" className="mb-[7px] block text-[13px] text-[#616161]">
+                                    새 비밀번호
+                                </label>
+                                <input
+                                    id="new-password"
+                                    type="password"
+                                    autoComplete="new-password"
+                                    placeholder="8자 이상"
+                                    {...register('newPassword')}
+                                    className={cn(inputClass, 'mb-4', errors.newPassword && 'border-brand-error focus:border-brand-error')}
+                                />
+
+                                <label htmlFor="confirm-password" className="mb-[7px] block text-[13px] text-[#616161]">
+                                    새 비밀번호 확인
+                                </label>
+                                <input
+                                    id="confirm-password"
+                                    type="password"
+                                    autoComplete="new-password"
+                                    placeholder="비밀번호 재입력"
+                                    {...register('confirmPassword')}
+                                    className={cn(inputClass, 'mb-2', errors.confirmPassword && 'border-brand-error focus:border-brand-error')}
+                                />
+
+                                {(errors.confirmPassword || errors.newPassword) && (
+                                    <p className="mb-2 flex items-center gap-[7px] text-[13px] text-brand-error">
+                                        <AlertCircle size={15} className="flex-shrink-0" />
+                                        {errors.confirmPassword?.message || errors.newPassword?.message}
+                                    </p>
+                                )}
+
+                                <button
+                                    type="submit"
+                                    disabled={confirmReset.isPending}
+                                    className="mt-6 flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black disabled:cursor-not-allowed disabled:opacity-70"
+                                >
+                                    {confirmReset.isPending ? <Loader2 className="animate-spin" size={20} /> : '비밀번호 변경'}
+                                </button>
+                            </form>
+                        </>
+                    )}
+
+                    {/* ── STEP 4: DONE ── */}
+                    {step === 'done' && (
+                        <>
+                            <div className="flex flex-1 flex-col items-center justify-center text-center">
+                                <div className="mb-7 flex h-[72px] w-[72px] items-center justify-center rounded-full bg-[#edfce9]">
+                                    <Check size={34} className="text-deep-green" strokeWidth={2} />
+                                </div>
+                                <h1 className="mb-3.5 font-display text-[30px] font-medium leading-[1.1] tracking-tightest text-primary">
+                                    비밀번호가 변경됐어요
+                                </h1>
+                                <p className="max-w-[280px] text-[16px] leading-[1.55] text-[#616161]">
+                                    새 비밀번호로 다시 로그인해주세요.
+                                </p>
+                            </div>
+                            <button
+                                type="button"
+                                onClick={goLogin}
+                                className="flex h-[52px] w-full items-center justify-center rounded-[32px] bg-primary text-[16px] font-medium text-canvas transition-colors hover:bg-cohere-black"
+                            >
+                                로그인하러 가기
+                            </button>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -125,7 +125,7 @@ export function LoginPage() {
                             <button
                                 type="button"
                                 className="text-[13px] text-action-blue"
-                                onClick={() => { /* TODO: 비밀번호 재설정 플로우 연결 */ }}
+                                onClick={() => navigate('/auth/forgot-password')}
                             >
                                 비밀번호를 잊으셨나요?
                             </button>

--- a/frontend/src/features/auth/types/auth.types.ts
+++ b/frontend/src/features/auth/types/auth.types.ts
@@ -39,3 +39,18 @@ export interface VerificationResponse {
     retryAt: string | null;
     expiresAt: string;
 }
+
+export interface PasswordResetRequest {
+    email: string;
+}
+
+export interface PasswordResetVerifyRequest {
+    email: string;
+    code: string;
+}
+
+export interface PasswordResetConfirmRequest {
+    email: string;
+    newPassword: string;
+    confirmPassword: string;
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -7,6 +7,7 @@ import { SignupPage } from '@/features/auth/pages/SignupPage';
 import { VerifyPage } from '@/features/auth/pages/VerifyPage';
 import { WelcomePage } from '@/features/auth/pages/WelcomePage';
 import { LoginPage } from '@/features/auth/pages/LoginPage';
+import { ForgotPasswordPage } from '@/features/auth/pages/ForgotPasswordPage';
 
 import { HomeTab } from '@/features/feed/pages/HomeTab';
 import { ExploreTab } from '@/features/explore/pages/ExploreTab';
@@ -32,6 +33,10 @@ export const router = createBrowserRouter([
     {
         path: '/auth/verify',
         element: <VerifyPage />,
+    },
+    {
+        path: '/auth/forgot-password',
+        element: <ForgotPasswordPage />,
     },
     {
         path: '/auth',


### PR DESCRIPTION
## 개요

클로드 디자인(tracer)의 비밀번호 재설정 4단계 플로우를 백엔드 `/api/auth/password-reset/*` API에 연결해 구현했습니다. 기존 로그인 화면의 "비밀번호를 잊으셨나요?" 버튼은 동작하지 않는 TODO 상태였는데, 이를 신규 페이지로 연결했습니다.

## 변경 사항

- `ForgotPasswordPage` 신규 추가 — 단일 컴포넌트에서 `step` 상태로 4개 화면 전환 (`email → verify → reset → done`)
- 비밀번호 재설정 API 3종 추가: `password-reset/request` · `verify` · `confirm`
- react-query 훅 3종 추가 (request / verify / confirm)
- `/auth/forgot-password` 라우트 추가
- 로그인 화면 "비밀번호를 잊으셨나요?" 버튼을 신규 페이지로 연결

## 백엔드 흐름 정합성

- `verify`는 **틀린 코드도 200 + status `PENDING`**을 반환하므로, `status === 'VERIFIED'` 검사로 분기하고 만료/잠금 예외는 별도 에러 메시지로 표시
- 미가입 이메일 / 코드 오류 / 동일 비밀번호 등 백엔드 예외 메시지를 화면에 노출
- 재설정용 DTO에는 길이 검증이 없어 프론트 zod로 8~20자 + 일치 검증 보강

## 디자인에서 제거한 항목

- 2단계의 "데모 화면입니다 — 아무 6자리 숫자나 입력…" 안내 문구 (실제 코드 검증이 동작하므로 제거)

## 화면

| 1. 이메일 입력 | 2. 인증코드 |
| :---: | :---: |
| <img src="https://raw.githubusercontent.com/honee8583/key-feed-mono/pr-assets/password-reset/docs/password-reset/step1-email.png" width="320"> | <img src="https://raw.githubusercontent.com/honee8583/key-feed-mono/pr-assets/password-reset/docs/password-reset/step2-verify.png" width="320"> |

| 3. 새 비밀번호 | 4. 완료 |
| :---: | :---: |
| <img src="https://raw.githubusercontent.com/honee8583/key-feed-mono/pr-assets/password-reset/docs/password-reset/step3-reset.png" width="320"> | <img src="https://raw.githubusercontent.com/honee8583/key-feed-mono/pr-assets/password-reset/docs/password-reset/step4-done.png" width="320"> |

## 확인

- `npx tsc -b` 통과
- `npx eslint` 통과
