### PR TITLE
feat: 검색 페이지 tracer 디자인 적용

### DIFF
--- a/frontend/src/features/search/components/SearchOverlay.tsx
+++ b/frontend/src/features/search/components/SearchOverlay.tsx
@@ -1,13 +1,16 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
-import { ArrowLeft, Search, X, ChevronRight, SearchX, Loader2 } from 'lucide-react';
+import { Search, X, Loader2 } from 'lucide-react';
 import { useUiStore } from '@/stores/uiStore';
 import { TRENDING_KEYWORDS } from '@/lib/mock';
 import type { Post } from '@/types';
+import { PostCard } from '@/features/feed/components/PostCard';
 import { PostDetailOverlay } from '@/features/feed/components/PostDetailOverlay';
 import { useFeed } from '@/features/feed/api/feedApi';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import { cn } from '@/utils/cn';
+import { useRecentSearches } from '../hooks/useRecentSearches';
 
 export function SearchOverlay() {
     const { isSearchOpen, closeSearch, unmountSearch } = useUiStore();
@@ -15,19 +18,20 @@ export function SearchOverlay() {
     const inputRef = useRef<HTMLInputElement>(null);
     const { contextSafe } = useGSAP({ scope: overlayRef });
 
-    const [searchQuery, setSearchQuery] = useState("");
-    const [isSearching, setIsSearching] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [committedQuery, setCommittedQuery] = useState('');
     const [selectedPost, setSelectedPost] = useState<Post | null>(null);
 
-    const {
-        data,
-        fetchNextPage,
-        hasNextPage,
-        isFetchingNextPage,
-        status
-    } = useFeed({ keyword: searchQuery, enabled: isSearching && searchQuery.trim().length > 0 });
+    const { recent, addRecent, clearRecent } = useRecentSearches();
 
-    const observerTarget = useIntersectionObserver({
+    const isSearching = committedQuery.trim().length > 0;
+
+    const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } = useFeed({
+        keyword: committedQuery,
+        enabled: isSearching,
+    });
+
+    const { targetRef } = useIntersectionObserver({
         onIntersect: fetchNextPage,
         enabled: hasNextPage && !isFetchingNextPage,
     });
@@ -38,13 +42,13 @@ export function SearchOverlay() {
             page.content.map((item) => ({
                 id: item.contentId,
                 company: item.sourceName,
-                logo: item.thumbnailUrl || '/favicon.ico',
+                logo: item.thumbnailUrl || '',
                 title: item.title,
                 excerpt: item.summary,
-                date: new Date(item.publishedAt).toLocaleDateString(),
-                category: 'Tech',
+                date: item.publishedAt,
+                category: '',
                 tags: [],
-                color: 'bg-indigo-500',
+                color: '',
                 readTime: '',
                 originalUrl: item.originalUrl,
                 bookmarkId: item.bookmarkId,
@@ -52,50 +56,43 @@ export function SearchOverlay() {
         );
     }, [data, isSearching]);
 
-    const handleSearchTrigger = (query: string) => {
-        if (query.trim()) {
-            setSearchQuery(query);
-            setIsSearching(true);
-        }
+    const runSearch = (query: string) => {
+        const trimmed = query.trim();
+        if (!trimmed) return;
+        setSearchQuery(trimmed);
+        setCommittedQuery(trimmed);
+        addRecent(trimmed);
     };
 
-    const handlePostClick = (post: Post) => {
-        setSelectedPost(post);
+    const handleClear = () => {
+        setSearchQuery('');
+        setCommittedQuery('');
+        inputRef.current?.focus();
     };
 
-    const handleBack = () => {
-        if (isSearching) {
-            setIsSearching(false);
-        } else {
-            closeSearch();
-            setSearchQuery("");
-        }
-    };
-
-    const handleClearSearch = () => {
-        setSearchQuery("");
-        setIsSearching(false);
+    const handleCancel = () => {
+        closeSearch();
+        setSearchQuery('');
+        setCommittedQuery('');
     };
 
     useEffect(() => {
         contextSafe(() => {
             if (isSearchOpen) {
-                gsap.to(overlayRef.current, { 
-                    y: 0, 
-                    opacity: 1, 
-                    duration: 0.4, 
-                    ease: "power3.out",
-                    onComplete: () => {
-                        inputRef.current?.focus();
-                    }
+                gsap.to(overlayRef.current, {
+                    y: 0,
+                    opacity: 1,
+                    duration: 0.4,
+                    ease: 'power3.out',
+                    onComplete: () => inputRef.current?.focus(),
                 });
             } else {
                 gsap.to(overlayRef.current, {
-                    y: "100%",
+                    y: '100%',
                     opacity: 0,
                     duration: 0.3,
-                    ease: "power2.in",
-                    onComplete: unmountSearch
+                    ease: 'power2.in',
+                    onComplete: unmountSearch,
                 });
             }
         })();
@@ -105,152 +102,153 @@ export function SearchOverlay() {
         <>
             <div
                 ref={overlayRef}
-                className="absolute inset-0 z-[100] bg-white flex justify-center translate-y-full opacity-0"
+                className="absolute inset-0 z-[100] flex translate-y-full justify-center bg-canvas opacity-0"
             >
-                <div className="w-full max-w-[480px] flex flex-col px-6 pt-10">
-                    <div className="flex items-center gap-3 mb-6">
-                        <button
-                            onClick={handleBack}
-                            className="p-2 bg-slate-50 border border-slate-100 rounded-full text-slate-600 shadow-sm active:scale-90 transition-transform"
-                        >
-                            <ArrowLeft size={20} />
-                        </button>
-                        <div className="flex-1 relative">
-                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400" size={18} />
+                <div className="flex w-full max-w-[480px] flex-col">
+                    {/* search bar */}
+                    <div className="flex items-center gap-3 px-5 pb-3.5 pt-14">
+                        <div className="flex h-[46px] flex-1 items-center gap-[9px] rounded-lg border border-hairline px-[13px]">
+                            <Search size={17} strokeWidth={1.8} className="shrink-0 text-muted" />
                             <input
                                 ref={inputRef}
                                 type="text"
                                 value={searchQuery}
                                 onChange={(e) => {
                                     setSearchQuery(e.target.value);
-                                    if (isSearching) setIsSearching(false);
+                                    if (e.target.value.trim() === '') setCommittedQuery('');
                                 }}
-                                onKeyDown={(e) => e.key === 'Enter' && handleSearchTrigger(searchQuery)}
-                                placeholder="관심 있는 키워드 검색"
-                                className="w-full bg-slate-50 border border-slate-100 rounded-2xl py-3 pl-11 pr-4 text-sm font-bold focus:ring-4 focus:ring-slate-100 outline-none transition-all placeholder:text-slate-400"
+                                onKeyDown={(e) => e.key === 'Enter' && runSearch(searchQuery)}
+                                placeholder="블로그, 글, 주제 검색"
+                                className="min-w-0 flex-1 bg-transparent text-[16px] text-ink outline-none placeholder:text-muted"
                             />
                             {searchQuery && (
                                 <button
-                                    onClick={handleClearSearch}
-                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-300 hover:text-slate-500"
+                                    type="button"
+                                    aria-label="검색어 지우기"
+                                    onClick={handleClear}
+                                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-hairline text-canvas"
                                 >
-                                    <X size={18} />
+                                    <X size={12} strokeWidth={2.4} />
                                 </button>
                             )}
                         </div>
+                        <button
+                            type="button"
+                            onClick={handleCancel}
+                            className="shrink-0 text-[15px] text-action-blue"
+                        >
+                            취소
+                        </button>
                     </div>
 
-                    <div className="flex-1 overflow-y-auto no-scrollbar pb-10">
+                    {/* body */}
+                    <div className="no-scrollbar flex-1 overflow-y-auto px-5 pb-8">
                         {!isSearching ? (
-                            <div className="animate-in fade-in slide-in-from-bottom-2 duration-300">
-                                <div className="mb-6">
-                                    <h4 className="text-[10px] font-black text-slate-400 uppercase tracking-widest mb-3 px-1">
-                                        최근 검색어
-                                    </h4>
-                                    <div className="flex flex-wrap gap-2">
-                                        {["React", "Node.js", "DeepSeek", "Toss"].map(tag => (
+                            <>
+                                {/* 최근 검색 */}
+                                <div className="flex items-center justify-between py-2.5 pt-3.5">
+                                    <span className="font-mono text-[11px] tracking-[0.6px] text-muted">
+                                        최근 검색
+                                    </span>
+                                    {recent.length > 0 && (
+                                        <button
+                                            type="button"
+                                            onClick={clearRecent}
+                                            className="text-[13px] text-[#75758a]"
+                                        >
+                                            전체 삭제
+                                        </button>
+                                    )}
+                                </div>
+                                {recent.length > 0 ? (
+                                    <div className="mb-7 flex flex-wrap gap-[9px]">
+                                        {recent.map((keyword) => (
                                             <button
-                                                key={tag}
-                                                onClick={() => handleSearchTrigger(tag)}
-                                                className="px-4 py-2 bg-slate-50 border border-slate-100 rounded-xl text-xs font-bold text-slate-600 hover:bg-slate-100 transition-colors"
+                                                key={keyword}
+                                                type="button"
+                                                onClick={() => runSearch(keyword)}
+                                                className="rounded-full bg-[#f2f2f2] px-3.5 py-[7px] text-[14px] text-ink"
                                             >
-                                                {tag}
+                                                {keyword}
                                             </button>
                                         ))}
                                     </div>
+                                ) : (
+                                    <p className="pb-7 pt-0.5 text-[14px] text-muted">
+                                        최근 검색 기록이 없어요.
+                                    </p>
+                                )}
+
+                                {/* 인기 검색어 */}
+                                <div className="pb-3.5 font-mono text-[11px] tracking-[0.6px] text-muted">
+                                    인기 검색어
                                 </div>
                                 <div>
-                                    <h4 className="text-[10px] font-black text-slate-400 uppercase tracking-widest mb-3 px-1">
-                                        추천 트렌드
-                                    </h4>
-                                    <div className="space-y-2">
-                                        {TRENDING_KEYWORDS.slice(0, 3).map((item) => (
-                                            <div
-                                                key={item.keyword}
-                                                onClick={() => handleSearchTrigger(item.keyword)}
-                                                className="flex items-center justify-between p-4 bg-slate-50 border border-slate-100 rounded-2xl hover:bg-slate-100 transition-all cursor-pointer group"
+                                    {TRENDING_KEYWORDS.map((item) => (
+                                        <button
+                                            key={item.keyword}
+                                            type="button"
+                                            onClick={() => runSearch(item.keyword)}
+                                            className="flex w-full items-center gap-3.5 border-b border-[#f2f2f2] py-3 text-left"
+                                        >
+                                            <span
+                                                className={cn(
+                                                    'w-[18px] font-mono text-[14px] font-bold',
+                                                    item.rank <= 3 ? 'text-coral' : 'text-muted'
+                                                )}
                                             >
-                                                <span className="text-xs font-bold text-slate-700 group-hover:text-slate-900">
-                                                    {item.keyword}
-                                                </span>
-                                                <ChevronRight size={14} className="text-slate-300" />
-                                            </div>
-                                        ))}
-                                    </div>
+                                                {item.rank}
+                                            </span>
+                                            <span className="flex-1 text-[16px] text-primary">
+                                                {item.keyword}
+                                            </span>
+                                        </button>
+                                    ))}
                                 </div>
-                            </div>
+                            </>
                         ) : (
-                            <div className="animate-in fade-in slide-in-from-bottom-2 duration-300">
-                                <div className="mb-4 px-1">
-                                    <h3 className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
-                                        검색 결과
-                                    </h3>
+                            <>
+                                <div className="py-3.5 pb-1.5 font-mono text-[11px] tracking-[0.6px] text-muted">
+                                    검색 결과{searchResults.length > 0 ? ` ${searchResults.length}` : ''}
                                 </div>
 
                                 {status === 'pending' ? (
-                                    <div className="flex justify-center py-20">
-                                        <Loader2 className="w-8 h-8 animate-spin text-slate-300" />
+                                    <div className="flex justify-center py-16">
+                                        <Loader2 className="h-6 w-6 animate-spin text-muted" />
                                     </div>
                                 ) : status === 'error' ? (
-                                    <div className="flex flex-col items-center justify-center py-20 opacity-40">
-                                        <SearchX size={48} className="mb-4" strokeWidth={1.5} />
-                                        <p className="text-[11px] font-black uppercase tracking-widest">
-                                            검색 중 오류가 발생했습니다
-                                        </p>
+                                    <div className="py-16 text-center text-[14px] text-muted">
+                                        검색 중 오류가 발생했어요.
                                     </div>
                                 ) : searchResults.length > 0 ? (
-                                    <div className="space-y-4">
-                                        {searchResults.map((post) => (
-                                            <div
-                                                key={post.id}
-                                                onClick={() => handlePostClick(post)}
-                                                className="bg-white border border-slate-100 p-4 rounded-3xl shadow-sm hover:border-indigo-100 transition-all cursor-pointer group flex gap-3"
-                                            >
-                                                <div className="flex-1">
-                                                    <div className="flex items-center gap-2 mb-1.5">
-                                                        <img src={post.logo} alt="" className="w-4 h-4 object-contain opacity-60" />
-                                                        <span className="text-[10px] font-bold text-slate-400 uppercase">
-                                                            {post.company}
-                                                        </span>
-                                                    </div>
-                                                    <h4 className="text-sm font-bold text-slate-800 leading-tight mb-1 group-hover:text-indigo-600 transition-colors">
-                                                        {post.title}
-                                                    </h4>
-                                                    <p className="text-[11px] text-slate-500 line-clamp-1 opacity-80">
-                                                        {post.excerpt}
-                                                    </p>
-                                                </div>
-                                                {post.thumbnail && (
-                                                    <div className="w-16 h-16 shrink-0 rounded-2xl overflow-hidden shadow-inner bg-slate-50 border border-slate-100">
-                                                        <img src={post.thumbnail} alt="" className="w-full h-full object-cover" />
-                                                    </div>
-                                                )}
-                                            </div>
-                                        ))}
-                                        <div ref={observerTarget.targetRef} className="h-10 flex items-center justify-center">
-                                            {isFetchingNextPage && <Loader2 className="w-5 h-5 animate-spin text-slate-400" />}
+                                    <>
+                                        <div>
+                                            {searchResults.map((post) => (
+                                                <PostCard key={post.id} post={post} onClick={setSelectedPost} />
+                                            ))}
+                                        </div>
+                                        <div ref={targetRef} className="mt-4 flex h-10 items-center justify-center">
+                                            {isFetchingNextPage && (
+                                                <Loader2 className="h-5 w-5 animate-spin text-muted" />
+                                            )}
+                                        </div>
+                                    </>
+                                ) : (
+                                    <div className="py-[70px] text-center text-muted">
+                                        <div className="font-mono text-[12px] tracking-[0.5px]">NO RESULTS</div>
+                                        <div className="mt-2 text-[15px]">
+                                            ‘{committedQuery}’에 대한 결과가 없어요.
                                         </div>
                                     </div>
-                                ) : (
-                                    <div className="flex flex-col items-center justify-center py-20 opacity-40">
-                                        <SearchX size={48} className="mb-4" strokeWidth={1.5} />
-                                        <p className="text-[11px] font-black uppercase tracking-widest">
-                                            검색 결과가 없습니다
-                                        </p>
-                                    </div>
                                 )}
-                            </div>
+                            </>
                         )}
                     </div>
                 </div>
             </div>
 
-            {/* Search also shares the PostDetail logic when a result is clicked */}
             {selectedPost && (
-                <PostDetailOverlay
-                    post={selectedPost}
-                    onClose={() => setSelectedPost(null)}
-                />
+                <PostDetailOverlay post={selectedPost} onClose={() => setSelectedPost(null)} />
             )}
         </>
     );

--- a/frontend/src/features/search/hooks/useRecentSearches.ts
+++ b/frontend/src/features/search/hooks/useRecentSearches.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'tracer.recentSearches';
+const MAX_RECENT = 10;
+
+function read(): string[] {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * 최근 검색어를 localStorage에 보관한다. 백엔드 API가 없는 클라이언트 전용 기능.
+ */
+export function useRecentSearches() {
+    const [recent, setRecent] = useState<string[]>(() => read());
+
+    // 다른 탭/오버레이에서 변경된 값을 반영
+    useEffect(() => {
+        const onStorage = (e: StorageEvent) => {
+            if (e.key === STORAGE_KEY) setRecent(read());
+        };
+        window.addEventListener('storage', onStorage);
+        return () => window.removeEventListener('storage', onStorage);
+    }, []);
+
+    const persist = useCallback((next: string[]) => {
+        setRecent(next);
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        } catch {
+            // 저장 실패는 조용히 무시 (사생활 모드 등)
+        }
+    }, []);
+
+    const addRecent = useCallback((keyword: string) => {
+        const trimmed = keyword.trim();
+        if (!trimmed) return;
+        setRecent((prev) => {
+            const next = [trimmed, ...prev.filter((k) => k !== trimmed)].slice(0, MAX_RECENT);
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+            } catch {
+                // ignore
+            }
+            return next;
+        });
+    }, []);
+
+    const clearRecent = useCallback(() => persist([]), [persist]);
+
+    return { recent, addRecent, clearRecent };
+}


### PR DESCRIPTION
## 개요

메인 피드 상단 검색 아이콘으로 진입하는 **검색 화면**(`SearchOverlay`)을 tracer 디자인 시스템에 맞춰 재디자인했습니다.

디자인 참조: tracer `tracer.dc.html`의 **SEARCH**

## 주요 변경

- 상단 검색바: hairline 테두리 + `rounded-lg` 인풋, 원형 X(지우기) 버튼, **취소**(action-blue) 텍스트로 정리 — 기존 `ArrowLeft` 뒤로가기 버튼/`slate-*` 스타일 제거
- 빈 상태: **최근 검색**(칩 + `전체 삭제`) / **인기 검색어**(랭킹 리스트, 1~3위 coral 강조)로 재구성 — 기존 `추천 트렌드` 카드(`ChevronRight`) 제거
- 검색 결과: `검색 결과 N` 라벨 + 결과 리스트, 무한 스크롤 유지, 결과 없음 시 `NO RESULTS` 빈 상태
- 결과 아이템은 피드의 **`PostCard`를 재사용** → 검색 결과에서도 북마크/폴더 변경 동작
- 토큰화: `cn()` 적용, `slate-*`/임의값 → tracer 토큰(`canvas`/`primary`/`ink`/`muted`/`hairline`/`coral`/`action-blue`) 사용

## 기능 개선

- **최근 검색을 localStorage 기반 실제 기능으로 구현** (`useRecentSearches`)
  - 검색 실행 시 자동 기록(중복 제거, 최대 10개), `전체 삭제` 지원, 칩 탭 시 재검색
  - 기존 하드코딩 mock(`["React", "Node.js", ...]`) 대체

## 검색 API

- 검색 결과는 기존 피드 API의 keyword 필터를 그대로 사용: `GET /api/feed?keyword=...` (`useFeed({ keyword })`, `useInfiniteQuery`)
- Enter 또는 최근/인기 검색어 탭 시 검색 실행, 입력을 비우면 최근/인기 화면으로 복귀

## 디자인 대비 mock 유지 / 제외 항목

- **인기 검색어**: 인기·실시간 검색어 API가 없어 기존 `TRENDING_KEYWORDS` mock 데이터를 사용(랭킹 UI만 반영)
- **결과 아이템 태그**: 피드 API가 태그를 제공하지 않아 표시하지 않음(홈 피드와 동일 처리)

## 검증

- `npx tsc -b` 통과
- `npx eslint` (변경 파일) 통과

