### PR TITLE
[feat] 검색창 최근 검색어 저장/조회/삭제 API 구현

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/auth/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/auth/service/impl/UserServiceImpl.java
@@ -11,13 +11,16 @@ import com.keyfeed.keyfeedmonolithic.domain.auth.service.UserService;
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.repository.BookmarkFolderRepository;
 import com.keyfeed.keyfeedmonolithic.domain.bookmark.repository.BookmarkRepository;
 import com.keyfeed.keyfeedmonolithic.domain.keyword.repository.KeywordRepository;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.RecentSearchService;
 import com.keyfeed.keyfeedmonolithic.domain.source.repository.UserSourceRepository;
 import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class UserServiceImpl implements UserService {
     private final UserSourceRepository userSourceRepository;
     private final BookmarkFolderRepository bookmarkFolderRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final RecentSearchService recentSearchService;
 
     @Override
     public void changePassword(Long userId, PasswordChangeRequestDto requestDto) {
@@ -61,8 +65,17 @@ public class UserServiceImpl implements UserService {
         bookmarkFolderRepository.deleteAllByUserId(userId);
         userSourceRepository.deleteAllByUserId(userId);
         keywordRepository.deleteAllByUserId(userId);
+        deleteRecentSearches(userId);
 
         userRepository.delete(user);
+    }
+
+    private void deleteRecentSearches(Long userId) {
+        try {
+            recentSearchService.deleteAll(userId);
+        } catch (Exception e) {
+            log.warn("탈퇴 회원 최근 검색어 삭제 실패 - TTL 만료로 정리됩니다. userId={}", userId, e);
+        }
     }
 
     private User resolveUser(Long userId) {

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
@@ -6,6 +6,7 @@ import com.keyfeed.keyfeedmonolithic.domain.content.dto.ContentFeedResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.content.entity.Content;
 import com.keyfeed.keyfeedmonolithic.domain.content.repository.ContentRepository;
 import com.keyfeed.keyfeedmonolithic.domain.feed.service.FeedService;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.RecentSearchService;
 import com.keyfeed.keyfeedmonolithic.domain.source.dto.SourceResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.source.service.SourceService;
 import com.keyfeed.keyfeedmonolithic.global.response.CommonPageResponse;
@@ -30,9 +31,14 @@ public class FeedServiceImpl implements FeedService {
     private final SourceService sourceService;
     private final BookmarkService bookmarkService;
     private final ContentRepository contentRepository;
+    private final RecentSearchService recentSearchService;
 
     @Override
     public CommonPageResponse<ContentFeedResponseDto> getPersonalizedFeeds(Long userId, Long lastId, int size, String keyword) {
+        if (lastId == null) {
+            recordRecentSearch(userId, keyword);
+        }
+
         List<SourceResponseDto> userSources = sourceService.getSourcesByUser(userId);
         if (CollectionUtils.isEmpty(userSources)) {
             return CommonPageResponse.empty();
@@ -70,6 +76,10 @@ public class FeedServiceImpl implements FeedService {
 
     @Override
     public OffsetPageResponse<ContentFeedResponseDto> getPersonalizedFeedsWithOffset(Long userId, int page, int size, String keyword) {
+        if (page == 0) {
+            recordRecentSearch(userId, keyword);
+        }
+
         List<SourceResponseDto> userSources = sourceService.getSourcesByUser(userId);
         if (CollectionUtils.isEmpty(userSources)) {
             return OffsetPageResponse.empty();
@@ -105,6 +115,18 @@ public class FeedServiceImpl implements FeedService {
                 .totalPages(contentPage.getTotalPages())
                 .hasNext(contentPage.hasNext())
                 .build();
+    }
+
+    private void recordRecentSearch(Long userId, String keyword) {
+        if (userId == null || !StringUtils.hasText(keyword)) {
+            return;
+        }
+
+        try {
+            recentSearchService.record(userId, keyword);
+        } catch (Exception e) {
+            log.warn("최근 검색어 저장 실패 - 피드 조회는 계속 진행합니다. userId={}, keyword={}", userId, keyword, e);
+        }
     }
 
     private List<Content> fetchContents(List<Long> sourceIds, Long lastId, String keyword, int size) {

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/controller/RecentSearchController.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/controller/RecentSearchController.java
@@ -1,0 +1,43 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.controller;
+
+import com.keyfeed.keyfeedmonolithic.domain.search.service.RecentSearchService;
+import com.keyfeed.keyfeedmonolithic.global.message.SuccessMessage;
+import com.keyfeed.keyfeedmonolithic.global.response.HttpResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class RecentSearchController {
+
+    private final RecentSearchService recentSearchService;
+
+    @GetMapping("/recent")
+    public ResponseEntity<?> getRecentSearches(@AuthenticationPrincipal Long userId) {
+        List<String> recentSearches = recentSearchService.getRecentSearches(userId);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.READ_SUCCESS.getMessage(), recentSearches));
+    }
+
+    @DeleteMapping("/recent/{keyword}")
+    public ResponseEntity<?> deleteRecentSearch(@AuthenticationPrincipal Long userId,
+                                                @PathVariable("keyword") String keyword) {
+        recentSearchService.delete(userId, keyword);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.DELETE_SUCCESS.getMessage(), null));
+    }
+
+    @DeleteMapping("/recent")
+    public ResponseEntity<?> deleteAllRecentSearches(@AuthenticationPrincipal Long userId) {
+        recentSearchService.deleteAll(userId);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.DELETE_SUCCESS.getMessage(), null));
+    }
+
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/repository/RecentSearchRedisRepository.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/repository/RecentSearchRedisRepository.java
@@ -20,14 +20,14 @@ public class RecentSearchRedisRepository {
     private static final Duration TTL = Duration.ofDays(30);
 
     public void add(Long userId, String keyword) {
-        String key = key(userId);
+        String key = buildKey(userId);
         redisTemplate.opsForZSet().add(key, keyword, System.currentTimeMillis());
         redisTemplate.opsForZSet().removeRange(key, 0, -(MAX_COUNT + 1));
         redisTemplate.expire(key, TTL);
     }
 
     public List<String> findAll(Long userId) {
-        Set<String> keywords = redisTemplate.opsForZSet().reverseRange(key(userId), 0, MAX_COUNT - 1);
+        Set<String> keywords = redisTemplate.opsForZSet().reverseRange(buildKey(userId), 0, MAX_COUNT - 1);
         if (keywords == null) {
             return List.of();
         }
@@ -35,14 +35,14 @@ public class RecentSearchRedisRepository {
     }
 
     public void remove(Long userId, String keyword) {
-        redisTemplate.opsForZSet().remove(key(userId), keyword);
+        redisTemplate.opsForZSet().remove(buildKey(userId), keyword);
     }
 
     public void removeAll(Long userId) {
-        redisTemplate.delete(key(userId));
+        redisTemplate.delete(buildKey(userId));
     }
 
-    private String key(Long userId) {
+    private String buildKey(Long userId) {
         return KEY_PREFIX + userId;
     }
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/repository/RecentSearchRedisRepository.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/repository/RecentSearchRedisRepository.java
@@ -1,0 +1,48 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+@RequiredArgsConstructor
+public class RecentSearchRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_PREFIX = "search:recent:";
+    private static final int MAX_COUNT = 10;
+    private static final Duration TTL = Duration.ofDays(30);
+
+    public void add(Long userId, String keyword) {
+        String key = key(userId);
+        redisTemplate.opsForZSet().add(key, keyword, System.currentTimeMillis());
+        redisTemplate.opsForZSet().removeRange(key, 0, -(MAX_COUNT + 1));
+        redisTemplate.expire(key, TTL);
+    }
+
+    public List<String> findAll(Long userId) {
+        Set<String> keywords = redisTemplate.opsForZSet().reverseRange(key(userId), 0, MAX_COUNT - 1);
+        if (keywords == null) {
+            return List.of();
+        }
+        return new ArrayList<>(keywords);
+    }
+
+    public void remove(Long userId, String keyword) {
+        redisTemplate.opsForZSet().remove(key(userId), keyword);
+    }
+
+    public void removeAll(Long userId) {
+        redisTemplate.delete(key(userId));
+    }
+
+    private String key(Long userId) {
+        return KEY_PREFIX + userId;
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/RecentSearchService.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/RecentSearchService.java
@@ -1,0 +1,15 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.service;
+
+import java.util.List;
+
+public interface RecentSearchService {
+
+    void record(Long userId, String keyword);
+
+    List<String> getRecentSearches(Long userId);
+
+    void delete(Long userId, String keyword);
+
+    void deleteAll(Long userId);
+
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/RecentSearchServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/RecentSearchServiceImpl.java
@@ -1,0 +1,39 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.service.impl;
+
+import com.keyfeed.keyfeedmonolithic.domain.search.repository.RecentSearchRedisRepository;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.RecentSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecentSearchServiceImpl implements RecentSearchService {
+
+    private final RecentSearchRedisRepository recentSearchRedisRepository;
+
+    @Override
+    public void record(Long userId, String keyword) {
+        if (userId == null || !StringUtils.hasText(keyword)) {
+            return;
+        }
+        recentSearchRedisRepository.add(userId, keyword.trim());
+    }
+
+    @Override
+    public List<String> getRecentSearches(Long userId) {
+        return recentSearchRedisRepository.findAll(userId);
+    }
+
+    @Override
+    public void delete(Long userId, String keyword) {
+        recentSearchRedisRepository.remove(userId, keyword);
+    }
+
+    @Override
+    public void deleteAll(Long userId) {
+        recentSearchRedisRepository.removeAll(userId);
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/SecurityConfig.java
@@ -77,6 +77,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/payment-methods/**").authenticated()
                 .requestMatchers("/api/subscriptions/**").authenticated()
                 .requestMatchers("/api/payment-history/**").authenticated()
+                .requestMatchers("/api/search/**").authenticated()
                 .requestMatchers("/internal/**").permitAll()
                 .requestMatchers("/actuator/**").permitAll()
                 .anyRequest().authenticated()

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImplTest.java
@@ -70,10 +70,13 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("구독 소스가 없으면 빈 피드를 반환한다")
     void 구독_소스가_없으면_빈_피드_반환() {
+        // given
         given(sourceService.getSourcesByUser(1L)).willReturn(Collections.emptyList());
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, null);
 
+        // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.isHasNext()).isFalse();
         assertThat(result.getNextCursorId()).isNull();
@@ -83,6 +86,7 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("키워드 없이 첫 페이지 조회 시 findFirstPage를 호출한다")
     void 키워드_없이_첫_페이지_조회() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, "MyBlog", "http://logo.com/1"));
         List<Content> contents = List.of(buildContent(10L, 1L, "Blog"));
 
@@ -95,8 +99,10 @@ class FeedServiceImplTest {
                 .build();
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Map.of("10", info));
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, null);
 
+        // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getSourceName()).isEqualTo("MyBlog");
         assertThat(result.getContent().get(0).getSourceLogoUrl()).isEqualTo("http://logo.com/1");
@@ -110,6 +116,7 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("키워드 없이 다음 페이지 조회 시 findNextPage를 호출한다")
     void 키워드_없이_다음_페이지_조회() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(5L, 1L, "Blog"));
 
@@ -117,8 +124,10 @@ class FeedServiceImplTest {
         given(contentRepository.findNextPage(anyList(), eq(10L), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, 10L, 10, null);
 
+        // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getSourceName()).isEqualTo("Blog");
         then(contentRepository).should().findNextPage(anyList(), eq(10L), any(Pageable.class));
@@ -127,6 +136,7 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("키워드로 첫 페이지 검색 시 searchFirstPage를 호출한다")
     void 키워드로_첫_페이지_검색() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, "Tech", "http://logo.com/1"));
         List<Content> contents = List.of(buildContent(7L, 1L, "TechBlog"));
 
@@ -134,8 +144,10 @@ class FeedServiceImplTest {
         given(contentRepository.searchFirstPage(anyList(), eq("spring"), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, "spring");
 
+        // then
         assertThat(result.getContent()).hasSize(1);
         then(contentRepository).should().searchFirstPage(anyList(), eq("spring"), any(Pageable.class));
     }
@@ -143,6 +155,7 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("키워드로 다음 페이지 검색 시 searchNextPage를 호출한다")
     void 키워드로_다음_페이지_검색() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(3L, 1L, "Blog"));
 
@@ -150,8 +163,10 @@ class FeedServiceImplTest {
         given(contentRepository.searchNextPage(anyList(), eq(20L), eq("java"), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, 20L, 10, "java");
 
+        // then
         assertThat(result.getContent()).hasSize(1);
         then(contentRepository).should().searchNextPage(anyList(), eq(20L), eq("java"), any(Pageable.class));
     }
@@ -159,6 +174,7 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("hasNext가 true일 때 nextCursorId가 마지막 컨텐츠 ID로 설정된다")
     void hasNext_true_시_nextCursorId_설정() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         // size=2 요청 → safeSize+1=3개 조회 → hasNext=true
         List<Content> contents = List.of(
@@ -171,8 +187,10 @@ class FeedServiceImplTest {
         given(contentRepository.findFirstPage(anyList(), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 2, null);
 
+        // then
         assertThat(result.isHasNext()).isTrue();
         assertThat(result.getNextCursorId()).isEqualTo(9L);
         assertThat(result.getContent()).hasSize(2);
@@ -181,19 +199,23 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("size가 50을 초과하면 50으로 제한된다")
     void size가_50_초과_시_50으로_제한() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
 
         given(sourceService.getSourcesByUser(1L)).willReturn(sources);
         given(contentRepository.findFirstPage(anyList(), any(Pageable.class))).willReturn(Collections.emptyList());
 
+        // when
         feedService.getPersonalizedFeeds(1L, null, 200, null);
 
+        // then
         then(contentRepository).should().findFirstPage(anyList(), argThat(pageable -> pageable.getPageSize() == 51));
     }
 
     @Test
     @DisplayName("북마크 조회 실패 시 예외 없이 피드를 반환한다")
     void 북마크_조회_실패_시_피드_정상_반환() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(1L, 1L, "Blog"));
 
@@ -201,8 +223,10 @@ class FeedServiceImplTest {
         given(contentRepository.findFirstPage(anyList(), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willThrow(new RuntimeException("북마크 서비스 오류"));
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, null);
 
+        // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).getBookmarkId()).isNull();
     }
@@ -210,6 +234,7 @@ class FeedServiceImplTest {
     @Test
     @DisplayName("사용자정의명이 없는 소스는 원본 소스명을 사용한다")
     void 사용자정의명_없으면_원본_소스명_사용() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(1L, 1L, "OriginalSourceName"));
 
@@ -217,14 +242,17 @@ class FeedServiceImplTest {
         given(contentRepository.findFirstPage(anyList(), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, null);
 
+        // then
         assertThat(result.getContent().get(0).getSourceName()).isEqualTo("OriginalSourceName");
     }
 
     @Test
     @DisplayName("소스 조회를 단 한 번만 호출한다")
     void 소스_조회_단_한_번만_호출() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, "Blog", "http://logo.com"));
         List<Content> contents = List.of(buildContent(1L, 1L, "Blog"));
 
@@ -232,14 +260,17 @@ class FeedServiceImplTest {
         given(contentRepository.findFirstPage(anyList(), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         feedService.getPersonalizedFeeds(1L, null, 10, null);
 
+        // then
         then(sourceService).should(times(1)).getSourcesByUser(1L);
     }
 
     @Test
     @DisplayName("키워드 검색 첫 페이지 조회 시 최근 검색어를 저장한다")
     void 키워드_검색_첫_페이지_시_최근_검색어_저장() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(7L, 1L, "Blog"));
 
@@ -247,14 +278,17 @@ class FeedServiceImplTest {
         given(contentRepository.searchFirstPage(anyList(), eq("spring"), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         feedService.getPersonalizedFeeds(1L, null, 10, "spring");
 
+        // then
         then(recentSearchService).should(times(1)).record(1L, "spring");
     }
 
     @Test
     @DisplayName("키워드 검색 다음 페이지 조회 시에는 최근 검색어를 저장하지 않는다")
     void 키워드_검색_다음_페이지_시_최근_검색어_저장_안함() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(3L, 1L, "Blog"));
 
@@ -262,14 +296,17 @@ class FeedServiceImplTest {
         given(contentRepository.searchNextPage(anyList(), eq(20L), eq("java"), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         feedService.getPersonalizedFeeds(1L, 20L, 10, "java");
 
+        // then
         then(recentSearchService).should(never()).record(anyLong(), anyString());
     }
 
     @Test
     @DisplayName("키워드가 없으면 최근 검색어를 저장하지 않는다")
     void 키워드_없으면_최근_검색어_저장_안함() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(1L, 1L, "Blog"));
 
@@ -277,14 +314,17 @@ class FeedServiceImplTest {
         given(contentRepository.findFirstPage(anyList(), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         feedService.getPersonalizedFeeds(1L, null, 10, null);
 
+        // then
         then(recentSearchService).should(never()).record(anyLong(), anyString());
     }
 
     @Test
     @DisplayName("최근 검색어 저장이 실패해도 피드는 정상 반환된다")
     void 최근_검색어_저장_실패해도_피드_정상_반환() {
+        // given
         List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
         List<Content> contents = List.of(buildContent(7L, 1L, "Blog"));
 
@@ -293,28 +333,36 @@ class FeedServiceImplTest {
         given(contentRepository.searchFirstPage(anyList(), eq("spring"), any(Pageable.class))).willReturn(contents);
         given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
 
+        // when
         CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, "spring");
 
+        // then
         assertThat(result.getContent()).hasSize(1);
     }
 
     @Test
     @DisplayName("오프셋 검색 첫 페이지 조회 시 최근 검색어를 저장한다")
     void 오프셋_검색_첫_페이지_시_최근_검색어_저장() {
+        // given
         given(sourceService.getSourcesByUser(1L)).willReturn(Collections.emptyList());
 
+        // when
         feedService.getPersonalizedFeedsWithOffset(1L, 0, 10, "spring");
 
+        // then
         then(recentSearchService).should(times(1)).record(1L, "spring");
     }
 
     @Test
     @DisplayName("오프셋 검색 두 번째 페이지 조회 시에는 최근 검색어를 저장하지 않는다")
     void 오프셋_검색_두번째_페이지_시_최근_검색어_저장_안함() {
+        // given
         given(sourceService.getSourcesByUser(1L)).willReturn(Collections.emptyList());
 
+        // when
         feedService.getPersonalizedFeedsWithOffset(1L, 1, 10, "spring");
 
+        // then
         then(recentSearchService).should(never()).record(anyLong(), anyString());
     }
 }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImplTest.java
@@ -5,6 +5,7 @@ import com.keyfeed.keyfeedmonolithic.domain.bookmark.service.BookmarkService;
 import com.keyfeed.keyfeedmonolithic.domain.content.dto.ContentFeedResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.content.entity.Content;
 import com.keyfeed.keyfeedmonolithic.domain.content.repository.ContentRepository;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.RecentSearchService;
 import com.keyfeed.keyfeedmonolithic.domain.source.dto.SourceResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.source.service.SourceService;
 import com.keyfeed.keyfeedmonolithic.global.response.CommonPageResponse;
@@ -39,6 +40,9 @@ class FeedServiceImplTest {
 
     @Mock
     private ContentRepository contentRepository;
+
+    @Mock
+    private RecentSearchService recentSearchService;
 
     private SourceResponseDto buildSource(Long sourceId, String name, String logoUrl) {
         return SourceResponseDto.builder()
@@ -231,5 +235,86 @@ class FeedServiceImplTest {
         feedService.getPersonalizedFeeds(1L, null, 10, null);
 
         then(sourceService).should(times(1)).getSourcesByUser(1L);
+    }
+
+    @Test
+    @DisplayName("키워드 검색 첫 페이지 조회 시 최근 검색어를 저장한다")
+    void 키워드_검색_첫_페이지_시_최근_검색어_저장() {
+        List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
+        List<Content> contents = List.of(buildContent(7L, 1L, "Blog"));
+
+        given(sourceService.getSourcesByUser(1L)).willReturn(sources);
+        given(contentRepository.searchFirstPage(anyList(), eq("spring"), any(Pageable.class))).willReturn(contents);
+        given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
+
+        feedService.getPersonalizedFeeds(1L, null, 10, "spring");
+
+        then(recentSearchService).should(times(1)).record(1L, "spring");
+    }
+
+    @Test
+    @DisplayName("키워드 검색 다음 페이지 조회 시에는 최근 검색어를 저장하지 않는다")
+    void 키워드_검색_다음_페이지_시_최근_검색어_저장_안함() {
+        List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
+        List<Content> contents = List.of(buildContent(3L, 1L, "Blog"));
+
+        given(sourceService.getSourcesByUser(1L)).willReturn(sources);
+        given(contentRepository.searchNextPage(anyList(), eq(20L), eq("java"), any(Pageable.class))).willReturn(contents);
+        given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
+
+        feedService.getPersonalizedFeeds(1L, 20L, 10, "java");
+
+        then(recentSearchService).should(never()).record(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("키워드가 없으면 최근 검색어를 저장하지 않는다")
+    void 키워드_없으면_최근_검색어_저장_안함() {
+        List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
+        List<Content> contents = List.of(buildContent(1L, 1L, "Blog"));
+
+        given(sourceService.getSourcesByUser(1L)).willReturn(sources);
+        given(contentRepository.findFirstPage(anyList(), any(Pageable.class))).willReturn(contents);
+        given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
+
+        feedService.getPersonalizedFeeds(1L, null, 10, null);
+
+        then(recentSearchService).should(never()).record(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("최근 검색어 저장이 실패해도 피드는 정상 반환된다")
+    void 최근_검색어_저장_실패해도_피드_정상_반환() {
+        List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
+        List<Content> contents = List.of(buildContent(7L, 1L, "Blog"));
+
+        willThrow(new RuntimeException("Redis 연결 오류")).given(recentSearchService).record(1L, "spring");
+        given(sourceService.getSourcesByUser(1L)).willReturn(sources);
+        given(contentRepository.searchFirstPage(anyList(), eq("spring"), any(Pageable.class))).willReturn(contents);
+        given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
+
+        CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, "spring");
+
+        assertThat(result.getContent()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("오프셋 검색 첫 페이지 조회 시 최근 검색어를 저장한다")
+    void 오프셋_검색_첫_페이지_시_최근_검색어_저장() {
+        given(sourceService.getSourcesByUser(1L)).willReturn(Collections.emptyList());
+
+        feedService.getPersonalizedFeedsWithOffset(1L, 0, 10, "spring");
+
+        then(recentSearchService).should(times(1)).record(1L, "spring");
+    }
+
+    @Test
+    @DisplayName("오프셋 검색 두 번째 페이지 조회 시에는 최근 검색어를 저장하지 않는다")
+    void 오프셋_검색_두번째_페이지_시_최근_검색어_저장_안함() {
+        given(sourceService.getSourcesByUser(1L)).willReturn(Collections.emptyList());
+
+        feedService.getPersonalizedFeedsWithOffset(1L, 1, 10, "spring");
+
+        then(recentSearchService).should(never()).record(anyLong(), anyString());
     }
 }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/RecentSearchServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/RecentSearchServiceImplTest.java
@@ -1,0 +1,102 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.service.impl;
+
+import com.keyfeed.keyfeedmonolithic.domain.search.repository.RecentSearchRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class RecentSearchServiceImplTest {
+
+    @InjectMocks
+    private RecentSearchServiceImpl recentSearchService;
+
+    @Mock
+    private RecentSearchRedisRepository recentSearchRedisRepository;
+
+    @Test
+    @DisplayName("검색어를 트리밍하여 저장한다")
+    void 검색어_트리밍_후_저장() {
+        // when
+        recentSearchService.record(1L, "  spring  ");
+
+        // then
+        then(recentSearchRedisRepository).should(times(1)).add(1L, "spring");
+    }
+
+    @Test
+    @DisplayName("빈 검색어는 저장하지 않는다")
+    void 빈_검색어_저장_안함() {
+        // when
+        recentSearchService.record(1L, "   ");
+
+        // then
+        then(recentSearchRedisRepository).should(never()).add(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("검색어가 null이면 저장하지 않는다")
+    void null_검색어_저장_안함() {
+        // when
+        recentSearchService.record(1L, null);
+
+        // then
+        then(recentSearchRedisRepository).should(never()).add(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 저장하지 않는다")
+    void null_userId_저장_안함() {
+        // when
+        recentSearchService.record(null, "spring");
+
+        // then
+        then(recentSearchRedisRepository).should(never()).add(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("최근 검색어 목록을 최신순으로 조회한다")
+    void 최근_검색어_목록_조회() {
+        // given
+        given(recentSearchRedisRepository.findAll(1L)).willReturn(List.of("java", "spring"));
+
+        // when
+        List<String> result = recentSearchService.getRecentSearches(1L);
+
+        // then
+        assertThat(result).containsExactly("java", "spring");
+    }
+
+    @Test
+    @DisplayName("특정 검색어를 삭제한다")
+    void 특정_검색어_삭제() {
+        // when
+        recentSearchService.delete(1L, "spring");
+
+        // then
+        then(recentSearchRedisRepository).should(times(1)).remove(1L, "spring");
+    }
+
+    @Test
+    @DisplayName("전체 검색어를 삭제한다")
+    void 전체_검색어_삭제() {
+        // when
+        recentSearchService.deleteAll(1L);
+
+        // then
+        then(recentSearchRedisRepository).should(times(1)).removeAll(1L);
+    }
+}


### PR DESCRIPTION
## 요약

- 최근 검색어를 Redis Sorted Set(`search:recent:{userId}`)에 사용자별로 보관하는 `search` 도메인 신규 추가
- 최근 검색어 API 3개 구현:

| 메서드 | 경로 | 설명 |
|---|---|---|
| `GET` | `/api/search/recent` | 최근 검색어 목록 조회 (최신순 최대 10개) |
| `DELETE` | `/api/search/recent/{keyword}` | 특정 검색어 삭제 |
| `DELETE` | `/api/search/recent` | 전체 삭제 |

- 저장은 별도 API 없이 **피드 키워드 검색 첫 페이지 조회 시 백엔드가 자동 기록** (`FeedServiceImpl`, 커서 `lastId == null` / 오프셋 `page == 0`일 때만)
- 회원 탈퇴 시 최근 검색어 정리 추가 (`UserServiceImpl.withdraw`)
- `SecurityConfig`에 `/api/search/**` 인증 매처 명시

### 발생 쿼리 수

- `GET /api/search/recent`: **DB 쿼리 0** — Redis `ZREVRANGE` 1회
- `DELETE /api/search/recent/{keyword}`: **DB 쿼리 0** — Redis `ZREM` 1회
- `DELETE /api/search/recent`: **DB 쿼리 0** — Redis `DEL` 1회
- 저장 훅이 붙은 `GET /api/feed`(키워드 검색 첫 페이지): 기존 DB 쿼리 3개 **증가 없음** + Redis 명령 3회(`ZADD` + `ZREMRANGEBYRANK` 트림 + `EXPIRE`) 추가

## 변경 이유

- 프론트는 화면 우선 구성을 위해 최근 검색어를 localStorage로 임시 구현한 상태 (`useRecentSearches.ts`) — 서버 보관으로 전환해야 기기 간 동기화와 탈퇴 시 데이터 정리가 가능
- 저장을 프론트 호출이 아닌 백엔드 검색 시점에 기록하는 이유: 검색 행위와 기록의 원자성이 보장되고, 이슈의 API 목록(조회/삭제만 존재)과도 일치
- 첫 페이지에서만 기록하는 이유: 무한 스크롤로 다음 페이지를 조회할 때마다 같은 키워드가 재기록되는 것을 방지

## 구현 방식

- **Redis Sorted Set** 채택: score를 타임스탬프로 사용해 "중복 시 최신순 재등록"이 `ZADD` 한 번으로 해결되고, `ZREMRANGEBYRANK`로 최대 10개 유지
- **TTL 30일**: 미사용 사용자의 데이터가 자동 정리되며, 탈퇴 시 Redis 삭제가 실패해도 TTL이 최종 정리를 보장 (그래서 탈퇴 트랜잭션은 Redis 장애에 실패하지 않도록 분리)
- **피드 조회 보호**: 최근 검색어 저장 실패(Redis 장애)는 warn 로그 후 무시 — 검색 기능 자체는 영향 없음 (`recordRecentSearch` try-catch, 기존 `attachBookmarkStatus`와 동일한 graceful 패턴)
- 기존 `KeywordCacheRepository`(Redis Set) 패턴과 동일하게 `StringRedisTemplate` 기반 리포지토리로 구성

## DB 변경

없음 (Redis만 사용, 마이그레이션 불필요)

## 테스트

- `RecentSearchServiceImplTest` (신규 7건): 트리밍 저장, 빈/null 검색어·null userId 무시, 조회/개별 삭제/전체 삭제 위임
- `FeedServiceImplTest` (6건 추가): 검색 첫 페이지 저장, 다음 페이지·키워드 없음 시 미저장(커서/오프셋 모두), Redis 실패 시 피드 정상 반환
- `./gradlew clean build` 전체 통과

## 리뷰 포인트

- 최근 검색어 저장 시점을 백엔드(피드 검색)에 둔 설계가 적절한지 — 대안은 프론트가 명시적으로 저장 API를 호출하는 방식입니다.
- TTL 30일, 최대 10개 값이 적절한지 확인 부탁드립니다.

## 체크리스트

- [x] 테스트 통과
- [x] 셀프 리뷰 완료
- [ ] 프론트엔드 전환 (localStorage → API 연동, 항목별 삭제 버튼)은 **별도 PR**로 진행

## 관련 이슈

- #61 (백엔드 작업 항목 해결 — 프론트 전환이 별도 PR로 남아 있어 자동 종료하지 않음)
