### PR TITLE
[feat] 실시간 검색어 순위 집계 및 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImpl.java
@@ -7,6 +7,7 @@ import com.keyfeed.keyfeedmonolithic.domain.content.entity.Content;
 import com.keyfeed.keyfeedmonolithic.domain.content.repository.ContentRepository;
 import com.keyfeed.keyfeedmonolithic.domain.feed.service.FeedService;
 import com.keyfeed.keyfeedmonolithic.domain.search.service.RecentSearchService;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.TrendingSearchService;
 import com.keyfeed.keyfeedmonolithic.domain.source.dto.SourceResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.source.service.SourceService;
 import com.keyfeed.keyfeedmonolithic.global.response.CommonPageResponse;
@@ -32,11 +33,12 @@ public class FeedServiceImpl implements FeedService {
     private final BookmarkService bookmarkService;
     private final ContentRepository contentRepository;
     private final RecentSearchService recentSearchService;
+    private final TrendingSearchService trendingSearchService;
 
     @Override
     public CommonPageResponse<ContentFeedResponseDto> getPersonalizedFeeds(Long userId, Long lastId, int size, String keyword) {
         if (lastId == null) {
-            recordRecentSearch(userId, keyword);
+            recordSearchEvent(userId, keyword);
         }
 
         List<SourceResponseDto> userSources = sourceService.getSourcesByUser(userId);
@@ -77,7 +79,7 @@ public class FeedServiceImpl implements FeedService {
     @Override
     public OffsetPageResponse<ContentFeedResponseDto> getPersonalizedFeedsWithOffset(Long userId, int page, int size, String keyword) {
         if (page == 0) {
-            recordRecentSearch(userId, keyword);
+            recordSearchEvent(userId, keyword);
         }
 
         List<SourceResponseDto> userSources = sourceService.getSourcesByUser(userId);
@@ -117,7 +119,7 @@ public class FeedServiceImpl implements FeedService {
                 .build();
     }
 
-    private void recordRecentSearch(Long userId, String keyword) {
+    private void recordSearchEvent(Long userId, String keyword) {
         if (userId == null || !StringUtils.hasText(keyword)) {
             return;
         }
@@ -126,6 +128,12 @@ public class FeedServiceImpl implements FeedService {
             recentSearchService.record(userId, keyword);
         } catch (Exception e) {
             log.warn("최근 검색어 저장 실패 - 피드 조회는 계속 진행합니다. userId={}, keyword={}", userId, keyword, e);
+        }
+
+        try {
+            trendingSearchService.increment(userId, keyword);
+        } catch (Exception e) {
+            log.warn("실시간 검색어 집계 실패 - 피드 조회는 계속 진행합니다. userId={}, keyword={}", userId, keyword, e);
         }
     }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/controller/TrendingSearchController.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/controller/TrendingSearchController.java
@@ -1,0 +1,30 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.controller;
+
+import com.keyfeed.keyfeedmonolithic.domain.search.dto.TrendingSearchResponseDto;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.TrendingSearchService;
+import com.keyfeed.keyfeedmonolithic.global.message.SuccessMessage;
+import com.keyfeed.keyfeedmonolithic.global.response.HttpResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class TrendingSearchController {
+
+    private final TrendingSearchService trendingSearchService;
+
+    @GetMapping("/trending")
+    public ResponseEntity<?> getTrendingSearches() {
+        List<TrendingSearchResponseDto> trending = trendingSearchService.getTrendingSearches();
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SuccessMessage.READ_SUCCESS.getMessage(), trending));
+    }
+
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/dto/TrendingSearchResponseDto.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/dto/TrendingSearchResponseDto.java
@@ -1,0 +1,16 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TrendingSearchResponseDto {
+
+    private final int rank;
+    private final String keyword;
+    private final long count;
+
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/repository/TrendingSearchRedisRepository.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/repository/TrendingSearchRedisRepository.java
@@ -1,0 +1,69 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+@Repository
+@RequiredArgsConstructor
+public class TrendingSearchRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String BUCKET_PREFIX = "search:trending:";
+    private static final String DEDUP_PREFIX = "search:trending:dedup:";
+    private static final String CACHE_KEY = "search:trending:cache";
+    private static final DateTimeFormatter BUCKET_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
+    private static final int WINDOW_HOURS = 24;
+    private static final Duration BUCKET_TTL = Duration.ofHours(25);
+    private static final Duration CACHE_TTL = Duration.ofMinutes(1);
+    private static final int MAX_COUNT = 10;
+
+    public void increment(Long userId, String keyword) {
+        String bucket = LocalDateTime.now().format(BUCKET_FORMATTER);
+        String dedupKey = DEDUP_PREFIX + bucket;
+
+        Long added = redisTemplate.opsForSet().add(dedupKey, userId + ":" + keyword);
+        if (added == null || added == 0) {
+            return;
+        }
+        redisTemplate.expire(dedupKey, BUCKET_TTL);
+
+        String bucketKey = BUCKET_PREFIX + bucket;
+        redisTemplate.opsForZSet().incrementScore(bucketKey, keyword, 1);
+        redisTemplate.expire(bucketKey, BUCKET_TTL);
+    }
+
+    public List<TypedTuple<String>> findTopWithScores() {
+        if (!Boolean.TRUE.equals(redisTemplate.hasKey(CACHE_KEY))) {
+            aggregateWindowIntoCache();
+        }
+
+        Set<TypedTuple<String>> tuples = redisTemplate.opsForZSet()
+                .reverseRangeWithScores(CACHE_KEY, 0, MAX_COUNT - 1);
+        if (tuples == null) {
+            return List.of();
+        }
+        return new ArrayList<>(tuples);
+    }
+
+    private void aggregateWindowIntoCache() {
+        LocalDateTime now = LocalDateTime.now();
+        List<String> bucketKeys = IntStream.range(0, WINDOW_HOURS)
+                .mapToObj(hoursAgo -> BUCKET_PREFIX + now.minusHours(hoursAgo).format(BUCKET_FORMATTER))
+                .toList();
+
+        redisTemplate.opsForZSet()
+                .unionAndStore(bucketKeys.get(0), bucketKeys.subList(1, bucketKeys.size()), CACHE_KEY);
+        redisTemplate.expire(CACHE_KEY, CACHE_TTL);
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/TrendingSearchService.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/TrendingSearchService.java
@@ -1,0 +1,13 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.service;
+
+import com.keyfeed.keyfeedmonolithic.domain.search.dto.TrendingSearchResponseDto;
+
+import java.util.List;
+
+public interface TrendingSearchService {
+
+    void increment(Long userId, String keyword);
+
+    List<TrendingSearchResponseDto> getTrendingSearches();
+
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/TrendingSearchServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/TrendingSearchServiceImpl.java
@@ -1,0 +1,43 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.service.impl;
+
+import com.keyfeed.keyfeedmonolithic.domain.search.dto.TrendingSearchResponseDto;
+import com.keyfeed.keyfeedmonolithic.domain.search.repository.TrendingSearchRedisRepository;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.TrendingSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TrendingSearchServiceImpl implements TrendingSearchService {
+
+    private final TrendingSearchRedisRepository trendingSearchRedisRepository;
+
+    @Override
+    public void increment(Long userId, String keyword) {
+        if (userId == null || !StringUtils.hasText(keyword)) {
+            return;
+        }
+        trendingSearchRedisRepository.increment(userId, keyword.trim());
+    }
+
+    @Override
+    public List<TrendingSearchResponseDto> getTrendingSearches() {
+        List<TypedTuple<String>> tuples = trendingSearchRedisRepository.findTopWithScores();
+
+        List<TrendingSearchResponseDto> result = new ArrayList<>();
+        for (int i = 0; i < tuples.size(); i++) {
+            TypedTuple<String> tuple = tuples.get(i);
+            result.add(TrendingSearchResponseDto.builder()
+                    .rank(i + 1)
+                    .keyword(tuple.getValue())
+                    .count(tuple.getScore() == null ? 0L : tuple.getScore().longValue())
+                    .build());
+        }
+        return result;
+    }
+}

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/SecurityConfig.java
@@ -77,6 +77,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/payment-methods/**").authenticated()
                 .requestMatchers("/api/subscriptions/**").authenticated()
                 .requestMatchers("/api/payment-history/**").authenticated()
+                .requestMatchers("/api/search/trending").permitAll()
                 .requestMatchers("/api/search/**").authenticated()
                 .requestMatchers("/internal/**").permitAll()
                 .requestMatchers("/actuator/**").permitAll()

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/feed/service/impl/FeedServiceImplTest.java
@@ -6,6 +6,7 @@ import com.keyfeed.keyfeedmonolithic.domain.content.dto.ContentFeedResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.content.entity.Content;
 import com.keyfeed.keyfeedmonolithic.domain.content.repository.ContentRepository;
 import com.keyfeed.keyfeedmonolithic.domain.search.service.RecentSearchService;
+import com.keyfeed.keyfeedmonolithic.domain.search.service.TrendingSearchService;
 import com.keyfeed.keyfeedmonolithic.domain.source.dto.SourceResponseDto;
 import com.keyfeed.keyfeedmonolithic.domain.source.service.SourceService;
 import com.keyfeed.keyfeedmonolithic.global.response.CommonPageResponse;
@@ -43,6 +44,9 @@ class FeedServiceImplTest {
 
     @Mock
     private RecentSearchService recentSearchService;
+
+    @Mock
+    private TrendingSearchService trendingSearchService;
 
     private SourceResponseDto buildSource(Long sourceId, String name, String logoUrl) {
         return SourceResponseDto.builder()
@@ -364,5 +368,74 @@ class FeedServiceImplTest {
 
         // then
         then(recentSearchService).should(never()).record(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("키워드 검색 첫 페이지 조회 시 실시간 검색어 집계를 호출한다")
+    void 키워드_검색_첫_페이지_시_실시간_검색어_집계() {
+        // given
+        List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
+        List<Content> contents = List.of(buildContent(7L, 1L, "Blog"));
+
+        given(sourceService.getSourcesByUser(1L)).willReturn(sources);
+        given(contentRepository.searchFirstPage(anyList(), eq("spring"), any(Pageable.class))).willReturn(contents);
+        given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
+
+        // when
+        feedService.getPersonalizedFeeds(1L, null, 10, "spring");
+
+        // then
+        then(trendingSearchService).should(times(1)).increment(1L, "spring");
+    }
+
+    @Test
+    @DisplayName("키워드 검색 다음 페이지 조회 시에는 실시간 검색어를 집계하지 않는다")
+    void 키워드_검색_다음_페이지_시_실시간_검색어_집계_안함() {
+        // given
+        List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
+        List<Content> contents = List.of(buildContent(3L, 1L, "Blog"));
+
+        given(sourceService.getSourcesByUser(1L)).willReturn(sources);
+        given(contentRepository.searchNextPage(anyList(), eq(20L), eq("java"), any(Pageable.class))).willReturn(contents);
+        given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
+
+        // when
+        feedService.getPersonalizedFeeds(1L, 20L, 10, "java");
+
+        // then
+        then(trendingSearchService).should(never()).increment(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("최근 검색어 저장이 실패해도 실시간 검색어 집계는 수행된다")
+    void 최근_검색어_저장_실패해도_실시간_검색어_집계_수행() {
+        // given
+        willThrow(new RuntimeException("Redis 연결 오류")).given(recentSearchService).record(1L, "spring");
+        given(sourceService.getSourcesByUser(1L)).willReturn(Collections.emptyList());
+
+        // when
+        feedService.getPersonalizedFeeds(1L, null, 10, "spring");
+
+        // then
+        then(trendingSearchService).should(times(1)).increment(1L, "spring");
+    }
+
+    @Test
+    @DisplayName("실시간 검색어 집계가 실패해도 피드는 정상 반환된다")
+    void 실시간_검색어_집계_실패해도_피드_정상_반환() {
+        // given
+        List<SourceResponseDto> sources = List.of(buildSource(1L, null, null));
+        List<Content> contents = List.of(buildContent(7L, 1L, "Blog"));
+
+        willThrow(new RuntimeException("Redis 연결 오류")).given(trendingSearchService).increment(1L, "spring");
+        given(sourceService.getSourcesByUser(1L)).willReturn(sources);
+        given(contentRepository.searchFirstPage(anyList(), eq("spring"), any(Pageable.class))).willReturn(contents);
+        given(bookmarkService.getBookmarkInfoMap(anyLong(), anyList())).willReturn(Collections.emptyMap());
+
+        // when
+        CommonPageResponse<ContentFeedResponseDto> result = feedService.getPersonalizedFeeds(1L, null, 10, "spring");
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
     }
 }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/TrendingSearchServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/search/service/impl/TrendingSearchServiceImplTest.java
@@ -1,0 +1,113 @@
+package com.keyfeed.keyfeedmonolithic.domain.search.service.impl;
+
+import com.keyfeed.keyfeedmonolithic.domain.search.dto.TrendingSearchResponseDto;
+import com.keyfeed.keyfeedmonolithic.domain.search.repository.TrendingSearchRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.DefaultTypedTuple;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class TrendingSearchServiceImplTest {
+
+    @InjectMocks
+    private TrendingSearchServiceImpl trendingSearchService;
+
+    @Mock
+    private TrendingSearchRedisRepository trendingSearchRedisRepository;
+
+    @Test
+    @DisplayName("검색어를 트리밍하여 집계한다")
+    void 검색어_트리밍_후_집계() {
+        // when
+        trendingSearchService.increment(1L, "  spring  ");
+
+        // then
+        then(trendingSearchRedisRepository).should(times(1)).increment(1L, "spring");
+    }
+
+    @Test
+    @DisplayName("빈 검색어는 집계하지 않는다")
+    void 빈_검색어_집계_안함() {
+        // when
+        trendingSearchService.increment(1L, "   ");
+
+        // then
+        then(trendingSearchRedisRepository).should(never()).increment(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 집계하지 않는다")
+    void null_userId_집계_안함() {
+        // when
+        trendingSearchService.increment(null, "spring");
+
+        // then
+        then(trendingSearchRedisRepository).should(never()).increment(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("검색 횟수 내림차순 순서대로 1부터 순위를 부여한다")
+    void 순위_부여_및_매핑() {
+        // given
+        given(trendingSearchRedisRepository.findTopWithScores()).willReturn(List.of(
+                new DefaultTypedTuple<>("spring", 42.0),
+                new DefaultTypedTuple<>("java", 17.0),
+                new DefaultTypedTuple<>("redis", 3.0)
+        ));
+
+        // when
+        List<TrendingSearchResponseDto> result = trendingSearchService.getTrendingSearches();
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getRank()).isEqualTo(1);
+        assertThat(result.get(0).getKeyword()).isEqualTo("spring");
+        assertThat(result.get(0).getCount()).isEqualTo(42L);
+        assertThat(result.get(1).getRank()).isEqualTo(2);
+        assertThat(result.get(1).getKeyword()).isEqualTo("java");
+        assertThat(result.get(2).getRank()).isEqualTo(3);
+        assertThat(result.get(2).getKeyword()).isEqualTo("redis");
+    }
+
+    @Test
+    @DisplayName("집계된 검색어가 없으면 빈 목록을 반환한다")
+    void 집계_없으면_빈_목록_반환() {
+        // given
+        given(trendingSearchRedisRepository.findTopWithScores()).willReturn(List.of());
+
+        // when
+        List<TrendingSearchResponseDto> result = trendingSearchService.getTrendingSearches();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("score가 null인 항목은 count 0으로 매핑한다")
+    void score_null이면_count_0() {
+        // given
+        given(trendingSearchRedisRepository.findTopWithScores()).willReturn(List.of(
+                new DefaultTypedTuple<>("spring", null)
+        ));
+
+        // when
+        List<TrendingSearchResponseDto> result = trendingSearchService.getTrendingSearches();
+
+        // then
+        assertThat(result.get(0).getCount()).isZero();
+    }
+}


### PR DESCRIPTION
## 요약

- 실제 **검색 횟수** 기반 실시간 검색어 순위 API 구현 (기존 `GET /api/keywords/trending`은 구독자 수 기준)

| 메서드 | 경로 | 설명 | 인증 |
|---|---|---|---|
| `GET` | `/api/search/trending` | 실시간 검색어 순위 조회 (rank, keyword, count 최대 10개) | 불필요 (permitAll) |

- 집계: **1시간 버킷 ZSET**(`search:trending:{yyyyMMddHH}`)에 검색 이벤트마다 `ZINCRBY`, 동일 사용자·동일 키워드는 버킷당 1회만 집계 (dedup Set의 `SADD` 반환값 활용)
- 조회: 최근 **24개 버킷을 `ZUNIONSTORE`로 합산**한 롤링 24시간 순위, 합산 결과는 **1분 캐시** 재사용
- 집계 시점: #115의 검색 이벤트 훅(`recordSearchEvent`)에 연결 — 검색 첫 페이지 조회 시에만, 최근 검색어 저장 실패와 격리
- API 위치: 이슈에 열어둔 두 안 중 **search 도메인**으로 결정 (집계 근원이 검색 이벤트이므로 keyword 도메인보다 응집도가 높음)

### 발생 쿼리 수

- `GET /api/search/trending`: **DB 쿼리 0**
  - 캐시 히트: Redis 2회 (`EXISTS` + `ZREVRANGE`)
  - 캐시 미스(1분당 최대 1회): Redis 4회 (`EXISTS` + `ZUNIONSTORE`(24키 합산) + `EXPIRE` + `ZREVRANGE`)
- 검색 훅이 붙은 `GET /api/feed`(키워드 검색 첫 페이지): DB 쿼리 **증가 없음**, Redis 최대 4회 추가 (`SADD` + `EXPIRE` + `ZINCRBY` + `EXPIRE`; 버킷 내 중복 검색이면 `SADD` 1회로 종료)

## 변경 이유

- 프론트 `SearchOverlay`의 "인기 검색어" 섹션이 목데이터(`TRENDING_KEYWORDS`)로 남아 있어 실데이터 공급원이 필요
- 구독자 수 기반 트렌딩은 정적 지표라 "지금 사람들이 무엇을 찾는가"를 표현하지 못함
- 단일 ZSET + TTL 방식은 만료 순간 순위가 통째로 사라지는 리셋 방식이라, 순위가 끊기지 않는 롤링 윈도우를 위해 버킷 분할 채택 (이슈 #62에서 확정한 설계)

## 구현 방식

- **버킷 분할 + 합산**: 시간마다 새 ZSET에 집계하고 조회 시 최근 24개를 합산 → 시간이 흐르면 오래된 조각이 자연스럽게 빠지는 롤링 24시간. 각 버킷 TTL 25시간으로 자동 정리
- **중복 집계 방지**: 버킷별 dedup Set(`search:trending:dedup:{bucket}`)에 `"{userId}:{keyword}"`를 `SADD` — 반환값 1일 때만 `ZINCRBY` 실행. Redis 단일 스레드에서 원자적으로 판정되므로 별도 락 불필요
- **합산 비용 완화**: `ZUNIONSTORE` 결과를 캐시 키에 저장하고 TTL 1분 — 실시간 검색어는 분 단위 신선도면 충분
- **장애 격리**: 집계 실패는 warn 로그 후 무시, 최근 검색어 저장과도 try-catch 분리 (한쪽 실패가 다른 쪽을 막지 않음)
- 비로그인 집계는 이슈 현행화대로 제외 (검색 엔드포인트가 인증 필수라 해당 트래픽 없음)

## DB 변경

없음 (Redis만 사용)

## 테스트

- `TrendingSearchServiceImplTest` (신규 6건): 트리밍 집계, 빈 검색어/null userId 무시, 순위 부여 매핑, 빈 목록, score null 방어
- `FeedServiceImplTest` (4건 추가): 검색 첫 페이지만 집계, 다음 페이지 제외, 최근 검색어 저장 실패와의 격리, 집계 실패 시 피드 정상 반환
- `./gradlew clean build` 전체 통과

## 리뷰 포인트

- 버킷 크기(1시간)·윈도우(24시간)·캐시 TTL(1분) 값이 적절한지 의견 부탁드립니다.
- 캐시 미스 시 동시 요청이 `ZUNIONSTORE`를 중복 수행할 수 있는데(결과 동일, 낭비만 발생), 트래픽 규모상 허용 가능하다고 판단해 락을 두지 않았습니다.

## 체크리스트

- [x] 테스트 통과
- [x] 셀프 리뷰 완료
- [ ] 프론트엔드 연동(목데이터 교체, 자동 갱신)은 **별도 PR**로 진행
- [ ] 순위 변동 표시(상승/하락/신규)는 이슈 #62 명시대로 후속 이슈로 분리

## 관련 이슈

- #62 (백엔드 작업 항목 해결 — 프론트 연동이 남아 있어 자동 종료하지 않음)
- #115 (선행 PR, 머지 완료 — 검색 이벤트 훅, search 도메인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
