### PR TITLE
[fix] 토스 API 호출을 DB 트랜잭션 밖으로 분리

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/BillingScheduler.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/BillingScheduler.java
@@ -17,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -46,7 +45,6 @@ public class BillingScheduler {
      */
     @Scheduled(cron = "0 0 10 * * *")
     @SchedulerLock(name = "BillingScheduler_executeScheduledPayments", lockAtMostFor = "PT1H", lockAtLeastFor = "PT1M")
-    @Transactional // TODO 단일 트랜잭션으로 분리
     public void executeScheduledPayments() {
         log.info("[BillingScheduler] 자동 결제 시작");
 
@@ -146,21 +144,18 @@ public class BillingScheduler {
             );
 
             // 결제 성공: nextBillingAt +1달 갱신, retryCount 초기화
-            subscription.updateNextBillingAt(subscription.getNextBillingAt().plusMonths(1));
-            subscription.resetRetryCount();
+            subscriptionWriter.updateBillingSuccess(subscription);
 
             log.info("[BillingScheduler] 결제 성공 - subscriptionId: {}, userId: {}", subscription.getId(), userId);
 
         } catch (PaymentFailedException | InvalidPaymentMethodException e) {
-            // 카드 거부/만료 등 결제 실패: retryCount +1
-            subscription.increaseRetryCount();
+            // 카드 거부/만료 등 결제 실패: retryCount +1, 3회 도달 시 PAUSED 전환
+            subscriptionWriter.updateBillingFailure(subscription, MAX_RETRY_COUNT);
 
             log.warn("[BillingScheduler] 결제 실패 - subscriptionId: {}, retryCount: {}, reason: {}",
                     subscription.getId(), subscription.getRetryCount(), e.getMessage());
 
-            // retryCount >= 3이면 PAUSED 전환 + 알림 발송
-            if (subscription.getRetryCount() >= MAX_RETRY_COUNT) {
-                subscription.pause();
+            if (subscription.getStatus() == SubscriptionStatus.PAUSED) {
                 sendPaymentFailedNotification(userId);
                 log.warn("[BillingScheduler] 구독 PAUSED 전환 - subscriptionId: {}, userId: {}", subscription.getId(), userId);
             }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/service/impl/SubscriptionServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/service/impl/SubscriptionServiceImpl.java
@@ -11,6 +11,7 @@ import com.keyfeed.keyfeedmonolithic.domain.payment.repository.PaymentMethodRepo
 import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
 import com.keyfeed.keyfeedmonolithic.domain.payment.service.BillingExecutor;
 import com.keyfeed.keyfeedmonolithic.domain.payment.service.SubscriptionService;
+import com.keyfeed.keyfeedmonolithic.domain.payment.writer.PaymentHistoryWriter;
 import com.keyfeed.keyfeedmonolithic.domain.payment.writer.SubscriptionWriter;
 import com.keyfeed.keyfeedmonolithic.global.client.toss.TossPaymentsClient;
 import com.keyfeed.keyfeedmonolithic.global.client.toss.dto.request.TossPaymentCancelRequest;
@@ -18,6 +19,7 @@ import com.keyfeed.keyfeedmonolithic.global.error.exception.EntityNotFoundExcept
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -36,9 +38,11 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     private final TossPaymentsClient tossPaymentsClient;
     private final BillingExecutor billingExecutor;
     private final SubscriptionWriter subscriptionWriter;
+    private final PaymentHistoryWriter paymentHistoryWriter;
     private final KeywordService keywordService;
 
     @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public SubscriptionStartResponseDto startSubscription(Long userId, SubscriptionStartRequestDto request) {
         // 1. 사용자 조회 (토스 API 호출에 필요한 customerKey, email, name)
         User user = userRepository.findById(userId)
@@ -105,6 +109,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     }
 
     @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public SubscriptionResumeResponseDto resumeSubscription(Long userId, SubscriptionResumeRequestDto request) {
         // 1. PAUSED 상태의 구독이 있는지 검증
         Subscription subscription = subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.PAUSED)
@@ -128,7 +133,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public SubscriptionRefundResponseDto refundSubscription(Long userId) {
         // 1. ACTIVE 상태의 구독이 있는지 검증
         Subscription subscription = subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)
@@ -159,10 +164,10 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         }
 
         // 5. payment_history 상태 CANCELED로 업데이트
-        history.markCanceled();
+        paymentHistoryWriter.updateCanceled(history);
 
         // 6. subscription 상태 REFUNDED로 업데이트 (즉시 만료)
-        subscription.refund();
+        subscriptionWriter.updateRefunded(subscription);
 
         return SubscriptionRefundResponseDto.from(subscription);
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/PaymentHistoryWriter.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/PaymentHistoryWriter.java
@@ -48,4 +48,10 @@ public class PaymentHistoryWriter {
         history.markFailed(reason);
         paymentHistoryRepository.save(history);
     }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateCanceled(PaymentHistory history) {
+        history.markCanceled();
+        paymentHistoryRepository.save(history);
+    }
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/SubscriptionWriter.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/SubscriptionWriter.java
@@ -57,4 +57,26 @@ public class SubscriptionWriter {
         subscription.resume(nextBillingAt, paymentMethod);
         subscriptionRepository.save(subscription);
     }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateBillingSuccess(Subscription subscription) {
+        subscription.updateNextBillingAt(subscription.getNextBillingAt().plusMonths(1));
+        subscription.resetRetryCount();
+        subscriptionRepository.save(subscription);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateBillingFailure(Subscription subscription, int maxRetryCount) {
+        subscription.increaseRetryCount();
+        if (subscription.getRetryCount() >= maxRetryCount) {
+            subscription.pause();
+        }
+        subscriptionRepository.save(subscription);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateRefunded(Subscription subscription) {
+        subscription.refund();
+        subscriptionRepository.save(subscription);
+    }
 }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/BillingSchedulerTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/BillingSchedulerTest.java
@@ -69,15 +69,13 @@ class BillingSchedulerTest {
         given(billingExecutor.execute(any(), any(), eq(subscription), anyString(), anyInt()))
                 .willReturn(chargeResult);
 
-        LocalDateTime beforeBilling = subscription.getNextBillingAt();
-
         // when
         billingScheduler.executeScheduledPayments();
 
         // then
-        assertThat(subscription.getNextBillingAt()).isEqualTo(beforeBilling.plusMonths(1));
-        assertThat(subscription.getRetryCount()).isZero();
-        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+        then(subscriptionWriter).should().updateBillingSuccess(subscription);
+        then(subscriptionWriter).should(never()).updateBillingFailure(any(), anyInt());
+        then(notificationService).should(never()).send(any());
     }
 
     @Test
@@ -91,6 +89,10 @@ class BillingSchedulerTest {
                 .willReturn(List.of(subscription));
         given(billingExecutor.execute(any(), any(), eq(subscription), anyString(), anyInt()))
                 .willThrow(new PaymentFailedException());
+        willAnswer(invocation -> {
+            subscription.increaseRetryCount();
+            return null;
+        }).given(subscriptionWriter).updateBillingFailure(subscription, 3);
 
         // when
         billingScheduler.executeScheduledPayments();
@@ -98,6 +100,7 @@ class BillingSchedulerTest {
         // then
         assertThat(subscription.getRetryCount()).isEqualTo(2);
         assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+        then(subscriptionWriter).should().updateBillingFailure(subscription, 3);
         then(notificationService).should(never()).send(any());
     }
 
@@ -112,6 +115,11 @@ class BillingSchedulerTest {
                 .willReturn(List.of(subscription));
         given(billingExecutor.execute(any(), any(), eq(subscription), anyString(), anyInt()))
                 .willThrow(new PaymentFailedException());
+        willAnswer(invocation -> {
+            subscription.increaseRetryCount();
+            subscription.pause();
+            return null;
+        }).given(subscriptionWriter).updateBillingFailure(subscription, 3);
 
         // when
         billingScheduler.executeScheduledPayments();
@@ -140,8 +148,8 @@ class BillingSchedulerTest {
         billingScheduler.executeScheduledPayments();
 
         // then
-        assertThat(subscription.getRetryCount()).isEqualTo(1);
-        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+        then(subscriptionWriter).should().updateBillingFailure(subscription, 3);
+        then(subscriptionWriter).should(never()).updateBillingSuccess(any());
     }
 
     @Test
@@ -179,8 +187,8 @@ class BillingSchedulerTest {
         billingScheduler.executeScheduledPayments();
 
         // then
-        assertThat(sub1.getRetryCount()).isEqualTo(1);
-        assertThat(sub2.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+        then(subscriptionWriter).should().updateBillingFailure(sub1, 3);
+        then(subscriptionWriter).should().updateBillingSuccess(sub2);
         then(billingExecutor).should(times(2)).execute(any(), any(), any(), anyString(), anyInt());
     }
 
@@ -199,6 +207,7 @@ class BillingSchedulerTest {
         // when & then
         assertThatCode(() -> billingScheduler.executeScheduledPayments()).doesNotThrowAnyException();
         assertThat(subscription.getRetryCount()).isZero();
+        then(subscriptionWriter).shouldHaveNoInteractions();
     }
 
     // ===== recoverReadyPayments =====

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/service/impl/SubscriptionServiceImplTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/service/impl/SubscriptionServiceImplTest.java
@@ -10,6 +10,7 @@ import com.keyfeed.keyfeedmonolithic.domain.payment.repository.PaymentHistoryRep
 import com.keyfeed.keyfeedmonolithic.domain.payment.repository.PaymentMethodRepository;
 import com.keyfeed.keyfeedmonolithic.domain.payment.repository.SubscriptionRepository;
 import com.keyfeed.keyfeedmonolithic.domain.payment.service.BillingExecutor;
+import com.keyfeed.keyfeedmonolithic.domain.payment.writer.PaymentHistoryWriter;
 import com.keyfeed.keyfeedmonolithic.domain.payment.writer.SubscriptionWriter;
 import com.keyfeed.keyfeedmonolithic.global.client.toss.TossPaymentsClient;
 import com.keyfeed.keyfeedmonolithic.global.client.toss.dto.response.TossBillingChargeResponse;
@@ -54,6 +55,9 @@ class SubscriptionServiceImplTest {
 
     @Mock
     private SubscriptionWriter subscriptionWriter;
+
+    @Mock
+    private PaymentHistoryWriter paymentHistoryWriter;
 
     @Mock
     private KeywordService keywordService;
@@ -392,6 +396,10 @@ class SubscriptionServiceImplTest {
                 subscription.getId(), PaymentHistoryStatus.DONE))
                 .willReturn(Optional.of(history));
         willDoNothing().given(tossPaymentsClient).cancelPayment(anyString(), any());
+        willAnswer(invocation -> {
+            subscription.refund();
+            return null;
+        }).given(subscriptionWriter).updateRefunded(subscription);
 
         // when
         SubscriptionRefundResponseDto result = subscriptionService.refundSubscription(userId);
@@ -400,7 +408,8 @@ class SubscriptionServiceImplTest {
         assertThat(result.getStatus()).isEqualTo("REFUNDED");
         assertThat(result.getCanceledAt()).isNotNull();
         assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.REFUNDED);
-        assertThat(history.getStatus()).isEqualTo(PaymentHistoryStatus.CANCELED);
+        then(paymentHistoryWriter).should().updateCanceled(history);
+        then(subscriptionWriter).should().updateRefunded(subscription);
     }
 
     @Test

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/PaymentHistoryWriterTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/PaymentHistoryWriterTest.java
@@ -162,6 +162,22 @@ class PaymentHistoryWriterTest {
         then(paymentHistoryRepository).should().save(history);
     }
 
+    // ===== updateCanceled =====
+
+    @Test
+    @DisplayName("updateCanceled - 상태가 CANCELED로 변경되고 저장된다")
+    void updateCanceled_CANCELED_변경() {
+        // given
+        PaymentHistory history = makeHistory(PaymentHistoryStatus.DONE);
+
+        // when
+        paymentHistoryWriter.updateCanceled(history);
+
+        // then
+        assertThat(history.getStatus()).isEqualTo(PaymentHistoryStatus.CANCELED);
+        then(paymentHistoryRepository).should().save(history);
+    }
+
     // ===== helpers =====
 
     private User makeUser(Long id) {

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/SubscriptionWriterTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/domain/payment/writer/SubscriptionWriterTest.java
@@ -199,6 +199,79 @@ class SubscriptionWriterTest {
         then(subscriptionRepository).should().save(subscription);
     }
 
+    // ===== updateBillingSuccess =====
+
+    @Test
+    @DisplayName("updateBillingSuccess - nextBillingAt이 1달 연장되고 retryCount가 초기화된다")
+    void updateBillingSuccess_결제일_연장_및_retryCount_초기화() {
+        // given
+        User user = makeUser(1L);
+        Subscription subscription = makeSubscription(user, SubscriptionStatus.ACTIVE);
+        subscription.increaseRetryCount();
+        LocalDateTime beforeBilling = subscription.getNextBillingAt();
+
+        // when
+        subscriptionWriter.updateBillingSuccess(subscription);
+
+        // then
+        assertThat(subscription.getNextBillingAt()).isEqualTo(beforeBilling.plusMonths(1));
+        assertThat(subscription.getRetryCount()).isZero();
+        then(subscriptionRepository).should().save(subscription);
+    }
+
+    // ===== updateBillingFailure =====
+
+    @Test
+    @DisplayName("updateBillingFailure - 한도 미만이면 retryCount만 증가하고 ACTIVE를 유지한다")
+    void updateBillingFailure_한도_미만_ACTIVE_유지() {
+        // given
+        User user = makeUser(1L);
+        Subscription subscription = makeSubscription(user, SubscriptionStatus.ACTIVE);
+
+        // when
+        subscriptionWriter.updateBillingFailure(subscription, 3);
+
+        // then
+        assertThat(subscription.getRetryCount()).isEqualTo(1);
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+        then(subscriptionRepository).should().save(subscription);
+    }
+
+    @Test
+    @DisplayName("updateBillingFailure - 한도 도달 시 PAUSED로 전환된다")
+    void updateBillingFailure_한도_도달_PAUSED_전환() {
+        // given
+        User user = makeUser(1L);
+        Subscription subscription = makeSubscription(user, SubscriptionStatus.ACTIVE);
+        subscription.increaseRetryCount();
+        subscription.increaseRetryCount();
+
+        // when
+        subscriptionWriter.updateBillingFailure(subscription, 3);
+
+        // then
+        assertThat(subscription.getRetryCount()).isEqualTo(3);
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.PAUSED);
+        then(subscriptionRepository).should().save(subscription);
+    }
+
+    // ===== updateRefunded =====
+
+    @Test
+    @DisplayName("updateRefunded - REFUNDED 상태로 전환되어 저장된다")
+    void updateRefunded_REFUNDED_전환() {
+        // given
+        User user = makeUser(1L);
+        Subscription subscription = makeSubscription(user, SubscriptionStatus.ACTIVE);
+
+        // when
+        subscriptionWriter.updateRefunded(subscription);
+
+        // then
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.REFUNDED);
+        then(subscriptionRepository).should().save(subscription);
+    }
+
     // ===== helpers =====
 
     private User makeUser(Long id) {


### PR DESCRIPTION
## 요약

DB 트랜잭션이 열린 채 토스 HTTP 호출을 기다리던 4개 지점의 트랜잭션 경계를 분리했습니다. 이제 토스 API 왕복 동안 점유되는 DB 커넥션이 0개이며, DB 쓰기는 writer의 `REQUIRES_NEW` 단기 트랜잭션으로만 수행됩니다.

| 지점 | 기존 | 변경 |
|---|---|---|
| `BillingScheduler.executeScheduledPayments` | 청구 대상 **전체 루프**를 단일 `@Transactional`로 감싼 채 건마다 토스 호출 (`// TODO 단일 트랜잭션으로 분리`) | 루프 트랜잭션 제거, 구독 상태 변경을 `SubscriptionWriter.updateBillingSuccess/updateBillingFailure`(REQUIRES_NEW)로 이동 |
| `startSubscription` | 클래스 레벨 `@Transactional(readOnly=true)` **상속**으로 토스 청구 중 커넥션 점유 | `NOT_SUPPORTED`로 오버라이드 |
| `resumeSubscription` | 〃 (동일한 상속 케이스) | `NOT_SUPPORTED`로 오버라이드 |
| `refundSubscription` | 쓰기 `@Transactional` 안에서 토스 취소 호출 + 더티 체킹 갱신 | `NOT_SUPPORTED` + `updateRefunded`/`updateCanceled` writer 메서드로 명시 저장 |

- `SubscriptionWriter`에 `updateBillingSuccess` / `updateBillingFailure(maxRetryCount)` / `updateRefunded`, `PaymentHistoryWriter`에 `updateCanceled` 추가 (모두 REQUIRES_NEW)
- `cancelSubscription`은 토스 호출이 없어 기존 `@Transactional` 유지

## 변경 이유

- 토스 응답이 타임아웃 수준으로 지연되는 상황에서 요청·배치가 몰리면, 토스 왕복 동안 점유된 커넥션들이 HikariCP 풀(25개)을 고갈시켜 결제와 무관한 API까지 함께 마비될 수 있음 (#104)
- 특히 `startSubscription`/`resumeSubscription`은 메서드에 어노테이션이 없어 문제가 없어 보이지만, 클래스 레벨 readOnly 트랜잭션을 상속받는 **은폐된 케이스**였음 — writer 패턴으로 경계를 분리해 둔 의도가 클래스 레벨 설정에 의해 무력화되어 있었음

## 구현 방식

- **더티 체킹 의존 제거가 핵심**: 루프 트랜잭션을 제거하면 `subscription.increaseRetryCount()` 같은 엔티티 변경이 저장되지 않으므로, 상태 전이 + 저장을 writer 메서드(REQUIRES_NEW)로 캡슐화. writer가 전달받은 동일 인스턴스를 변경하므로 호출부(스케줄러)는 이후 `getStatus() == PAUSED` 판정으로 알림 발송 여부를 결정
- `NOT_SUPPORTED`는 클래스 레벨 설정을 메서드 레벨에서 오버라이드하는 유일한 수단이라 명시적으로 선언 (어노테이션 부재 = 트랜잭션 없음이 아니었던 원인)
- 실패 한도(`MAX_RETRY_COUNT`) 정책은 스케줄러에 남기고 writer는 파라미터로 수신

## 트레이드오프 (리뷰 포인트)

- 기존에는 배치 루프가 한 트랜잭션이라 중간 실패 시 전체 롤백이었지만, 원래도 토스 청구는 롤백 불가능한 외부 부수효과라 "전체 롤백"이 정합성을 보장해주지 못했습니다. 분리 후에는 각 구독의 DB 상태가 개별 커밋되어 오히려 부분 실패 시에도 성공 건이 보존됩니다.
- `refundSubscription`은 토스 취소 성공 후 두 개의 짧은 트랜잭션(이력 CANCELED, 구독 REFUNDED)으로 나뉘어, 둘 사이에서 장애가 나면 불일치 창이 생깁니다. 기존 구조도 "토스 취소 성공 + DB 롤백" 불일치가 있었으므로 위험 총량은 동등하며, 근본 해결은 대사(reconciliation) 영역입니다.

## DB 변경

없음

## 테스트

- `BillingSchedulerTest`: 상태 변경 책임이 writer로 이동함에 따라 협력 검증으로 전환, PAUSED 전환 분기는 `willAnswer`로 writer 동작 시뮬레이션, 인프라 오류 시 `shouldHaveNoInteractions`로 "상태 저장 없음" 계약 고정
- `SubscriptionWriterTest` +4건 (결제 성공 갱신 / 실패 한도 미만 / 한도 도달 PAUSED / 환불), `PaymentHistoryWriterTest` +1건 (updateCanceled)
- `SubscriptionServiceImplTest` 환불 테스트를 writer 협력 검증으로 갱신
- `./gradlew clean build` 전체 통과

## 체크리스트

- [x] 테스트 통과
- [x] 셀프 리뷰 완료
- [ ] 부하 테스트로 커넥션 점유 개선 확인 (k6, 후속)

## 관련 이슈

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
