### PR TITLE
[fix] 예외 로깅 시 e.getMessage()로 인한 스택트레이스 유실 수정

### DIFF
--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/crawl/scheduler/CrawlScheduler.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/crawl/scheduler/CrawlScheduler.java
@@ -48,7 +48,7 @@ public class CrawlScheduler {
                     try {
                         crawlService.processSource(source);
                     } catch (Exception e) {
-                        log.error("소스 크롤링 실패 (소스 ID: {}, URL: {}) ERROR : {}", source.getId(), source.getUrl(), e.getMessage());
+                        log.error("소스 크롤링 실패 (소스 ID: {}, URL: {})", source.getId(), source.getUrl(), e);
                     }
                 });
             }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/crawl/service/RssFeedParser.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/crawl/service/RssFeedParser.java
@@ -100,7 +100,7 @@ public class RssFeedParser {
                 items.add(new FeedItem(guid, title, link, cleanSummary, thumbnailUrl, pubDate));
             }
         } catch (Exception e) {
-            log.error("RSS 피드 파싱 실패: URL={}, 에러={}", feedUrl, e.getMessage());
+            log.error("RSS 피드 파싱 실패: URL={}", feedUrl, e);
         }
         return new ParsedFeedResult(logoUrl, items);
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/notification/service/impl/NotificationServiceImpl.java
@@ -182,7 +182,7 @@ public class NotificationServiceImpl implements NotificationService {
                     .data(data));
         } catch (IOException e) {
             sseEmitterRepository.deleteById(emitterId);
-            log.error("SSE 연결 오류 발생 (Emitter 삭제)", e);
+            log.info("SSE 연결 종료로 emitter 제거 - emitterId: {} ({})", emitterId, e.toString());
         }
     }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/notification/service/impl/NotificationServiceImpl.java
@@ -182,7 +182,7 @@ public class NotificationServiceImpl implements NotificationService {
                     .data(data));
         } catch (IOException e) {
             sseEmitterRepository.deleteById(emitterId);
-            log.error("SSE 연결 오류 발생 (Emitter 삭제): {}", e.getMessage());
+            log.error("SSE 연결 오류 발생 (Emitter 삭제)", e);
         }
     }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/BillingScheduler.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/scheduler/BillingScheduler.java
@@ -152,8 +152,8 @@ public class BillingScheduler {
             // 카드 거부/만료 등 결제 실패: retryCount +1, 3회 도달 시 PAUSED 전환
             subscriptionWriter.updateBillingFailure(subscription, MAX_RETRY_COUNT);
 
-            log.warn("[BillingScheduler] 결제 실패 - subscriptionId: {}, retryCount: {}, reason: {}",
-                    subscription.getId(), subscription.getRetryCount(), e.getMessage());
+            log.warn("[BillingScheduler] 결제 실패 - subscriptionId: {}, retryCount: {}",
+                    subscription.getId(), subscription.getRetryCount(), e);
 
             if (subscription.getStatus() == SubscriptionStatus.PAUSED) {
                 sendPaymentFailedNotification(userId);
@@ -161,7 +161,7 @@ public class BillingScheduler {
             }
         } catch (Exception e) {
             // 인프라/네트워크 오류: retryCount 증가 없이 로그만 기록
-            log.error("[BillingScheduler] 결제 중 예상 외 오류 - subscriptionId: {}, error: {}", subscription.getId(), e.getMessage());
+            log.error("[BillingScheduler] 결제 중 예상 외 오류 - subscriptionId: {}", subscription.getId(), e);
         }
     }
 
@@ -178,12 +178,12 @@ public class BillingScheduler {
                 log.info("[BillingScheduler] READY 복구(FAILED) - orderId: {}", history.getOrderId());
             }
         } catch (Exception e) {
-            log.error("[BillingScheduler] READY 복구 실패 - orderId: {}, error: {}", history.getOrderId(), e.getMessage());
+            log.error("[BillingScheduler] READY 복구 실패 - orderId: {}", history.getOrderId(), e);
             try {
                 paymentHistoryWriter.updateFailed(history, "복구 중 오류 발생: " + e.getMessage());
             } catch (Exception markFailedException) {
-                log.error("[BillingScheduler] READY 복구 FAILED 마킹 실패 - orderId: {}, error: {}",
-                        history.getOrderId(), markFailedException.getMessage());
+                log.error("[BillingScheduler] READY 복구 FAILED 마킹 실패 - orderId: {}",
+                        history.getOrderId(), markFailedException);
             }
         }
     }
@@ -196,7 +196,7 @@ public class BillingScheduler {
                     .message(PAYMENT_FAILED_ALERT_MESSAGE)
                     .build());
         } catch (Exception e) {
-            log.error("[BillingScheduler] 알림 발송 실패 - userId: {}, error: {}", userId, e.getMessage());
+            log.error("[BillingScheduler] 알림 발송 실패 - userId: {}", userId, e);
         }
     }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/service/impl/SubscriptionServiceImpl.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/payment/service/impl/SubscriptionServiceImpl.java
@@ -159,7 +159,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                             .build()
             );
         } catch (Exception e) {
-            log.error("토스 환불 API 호출 실패: {}", e.getMessage());
+            log.error("토스 환불 API 호출 실패", e);
             throw new RefundFailedException();
         }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/source/validator/RssFeedValidator.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/domain/source/validator/RssFeedValidator.java
@@ -59,7 +59,7 @@ public class RssFeedValidator {
             return true;
 
         } catch (Exception e) {
-            log.error("RSS 피드 파싱 실패: {} - {}", feedUrl, e.getMessage());
+            log.error("RSS 피드 파싱 실패: {}", feedUrl, e);
             return false;
         }
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/client/toss/TossPaymentsClient.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/client/toss/TossPaymentsClient.java
@@ -71,8 +71,8 @@ public class TossPaymentsClient {
                     request.getCustomerKey(), mask(response.getBillingKey()), elapsed(start));
             return response;
         } catch (Exception e) {
-            log.error("[Toss] 빌링키 발급 실패 - customerKey: {}, elapsed: {}ms, error: {}",
-                    request.getCustomerKey(), elapsed(start), e.getMessage());
+            log.error("[Toss] 빌링키 발급 실패 - customerKey: {}, elapsed: {}ms",
+                    request.getCustomerKey(), elapsed(start), e);
             throw e;
         }
     }
@@ -95,8 +95,8 @@ public class TossPaymentsClient {
                     request.getOrderId(), response.getPaymentKey(), response.getApprovedAt(), elapsed(start));
             return response;
         } catch (Exception e) {
-            log.error("[Toss] 결제 실패 - orderId: {}, amount: {}, elapsed: {}ms, error: {}",
-                    request.getOrderId(), request.getAmount(), elapsed(start), e.getMessage());
+            log.error("[Toss] 결제 실패 - orderId: {}, amount: {}, elapsed: {}ms",
+                    request.getOrderId(), request.getAmount(), elapsed(start), e);
             throw e;
         }
     }
@@ -120,8 +120,8 @@ public class TossPaymentsClient {
             log.info("[Toss] 결제 취소 성공 - paymentKey: {}, elapsed: {}ms",
                     paymentKey, elapsed(start));
         } catch (Exception e) {
-            log.error("[Toss] 결제 취소 실패 - paymentKey: {}, elapsed: {}ms, error: {}",
-                    paymentKey, elapsed(start), e.getMessage());
+            log.error("[Toss] 결제 취소 실패 - paymentKey: {}, elapsed: {}ms",
+                    paymentKey, elapsed(start), e);
             throw e;
         }
     }
@@ -143,8 +143,8 @@ public class TossPaymentsClient {
                     orderId, response.getStatus(), elapsed(start));
             return response;
         } catch (Exception e) {
-            log.error("[Toss] 결제 조회 실패 - orderId: {}, elapsed: {}ms, error: {}",
-                    orderId, elapsed(start), e.getMessage());
+            log.error("[Toss] 결제 조회 실패 - orderId: {}, elapsed: {}ms",
+                    orderId, elapsed(start), e);
             throw e;
         }
     }
@@ -167,8 +167,8 @@ public class TossPaymentsClient {
             log.info("[Toss] 빌링키 삭제 성공 - billingKey: {}, elapsed: {}ms",
                     mask(billingKey), elapsed(start));
         } catch (Exception e) {
-            log.error("[Toss] 빌링키 삭제 실패 - billingKey: {}, elapsed: {}ms, error: {}",
-                    mask(billingKey), elapsed(start), e.getMessage());
+            log.error("[Toss] 빌링키 삭제 실패 - billingKey: {}, elapsed: {}ms",
+                    mask(billingKey), elapsed(start), e);
             throw e;
         }
     }
@@ -181,7 +181,7 @@ public class TossPaymentsClient {
             handleClientError(e);
             throw new InternalApiRequestException("Toss API 호출 실패: " + e.getMessage());
         } catch (ResourceAccessException e) {
-            log.error("Toss API 네트워크 오류: {}", e.getMessage());
+            log.error("Toss API 네트워크 오류", e);
             throw new InternalApiRequestException("Toss API 네트워크 오류: " + e.getMessage());
         }
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/client/toss/TossPaymentsClient.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/client/toss/TossPaymentsClient.java
@@ -64,17 +64,11 @@ public class TossPaymentsClient {
                 .path(PATH_BILLING_ISSUE)
                 .build().toUri();
 
-        try {
-            TossBillingIssueResponse response = record("issueBillingKey",
-                    () -> exchange(uri, HttpMethod.POST, request, TossBillingIssueResponse.class));
-            log.info("[Toss] 빌링키 발급 성공 - customerKey: {}, billingKey: {}, elapsed: {}ms",
-                    request.getCustomerKey(), mask(response.getBillingKey()), elapsed(start));
-            return response;
-        } catch (Exception e) {
-            log.error("[Toss] 빌링키 발급 실패 - customerKey: {}, elapsed: {}ms",
-                    request.getCustomerKey(), elapsed(start), e);
-            throw e;
-        }
+        TossBillingIssueResponse response = record("issueBillingKey",
+                () -> exchange(uri, HttpMethod.POST, request, TossBillingIssueResponse.class));
+        log.info("[Toss] 빌링키 발급 성공 - customerKey: {}, billingKey: {}, elapsed: {}ms",
+                request.getCustomerKey(), mask(response.getBillingKey()), elapsed(start));
+        return response;
     }
 
     // 결제 실행: 발급된 빌링키로 구독 첫 결제 및 자동결제를 실행한다
@@ -88,17 +82,11 @@ public class TossPaymentsClient {
                 .buildAndExpand(billingKey)
                 .toUri();
 
-        try {
-            TossBillingChargeResponse response = record("chargeBilling",
-                    () -> exchange(uri, HttpMethod.POST, request, TossBillingChargeResponse.class));
-            log.info("[Toss] 결제 성공 - orderId: {}, paymentKey: {}, approvedAt: {}, elapsed: {}ms",
-                    request.getOrderId(), response.getPaymentKey(), response.getApprovedAt(), elapsed(start));
-            return response;
-        } catch (Exception e) {
-            log.error("[Toss] 결제 실패 - orderId: {}, amount: {}, elapsed: {}ms",
-                    request.getOrderId(), request.getAmount(), elapsed(start), e);
-            throw e;
-        }
+        TossBillingChargeResponse response = record("chargeBilling",
+                () -> exchange(uri, HttpMethod.POST, request, TossBillingChargeResponse.class));
+        log.info("[Toss] 결제 성공 - orderId: {}, paymentKey: {}, approvedAt: {}, elapsed: {}ms",
+                request.getOrderId(), response.getPaymentKey(), response.getApprovedAt(), elapsed(start));
+        return response;
     }
 
     // 결제 취소: 결제 건을 취소하고 환불을 처리한다
@@ -112,18 +100,12 @@ public class TossPaymentsClient {
                 .buildAndExpand(paymentKey)
                 .toUri();
 
-        try {
-            record("cancelPayment", () -> {
-                exchange(uri, HttpMethod.POST, request, Void.class);
-                return null;
-            });
-            log.info("[Toss] 결제 취소 성공 - paymentKey: {}, elapsed: {}ms",
-                    paymentKey, elapsed(start));
-        } catch (Exception e) {
-            log.error("[Toss] 결제 취소 실패 - paymentKey: {}, elapsed: {}ms",
-                    paymentKey, elapsed(start), e);
-            throw e;
-        }
+        record("cancelPayment", () -> {
+            exchange(uri, HttpMethod.POST, request, Void.class);
+            return null;
+        });
+        log.info("[Toss] 결제 취소 성공 - paymentKey: {}, elapsed: {}ms",
+                paymentKey, elapsed(start));
     }
 
     // 결제 조회: orderId로 결제 건의 실제 처리 상태를 조회한다 (서버 재시작 시 READY 복구용)
@@ -136,17 +118,11 @@ public class TossPaymentsClient {
                 .buildAndExpand(orderId)
                 .toUri();
 
-        try {
-            TossPaymentQueryResponse response = record("getPaymentByOrderId",
-                    () -> exchange(uri, HttpMethod.GET, null, TossPaymentQueryResponse.class));
-            log.info("[Toss] 결제 조회 성공 - orderId: {}, status: {}, elapsed: {}ms",
-                    orderId, response.getStatus(), elapsed(start));
-            return response;
-        } catch (Exception e) {
-            log.error("[Toss] 결제 조회 실패 - orderId: {}, elapsed: {}ms",
-                    orderId, elapsed(start), e);
-            throw e;
-        }
+        TossPaymentQueryResponse response = record("getPaymentByOrderId",
+                () -> exchange(uri, HttpMethod.GET, null, TossPaymentQueryResponse.class));
+        log.info("[Toss] 결제 조회 성공 - orderId: {}, status: {}, elapsed: {}ms",
+                orderId, response.getStatus(), elapsed(start));
+        return response;
     }
 
     // 빌링키 삭제: 사용자가 결제 수단을 삭제할 때 빌링키를 만료시킨다
@@ -159,18 +135,12 @@ public class TossPaymentsClient {
                 .buildAndExpand(billingKey)
                 .toUri();
 
-        try {
-            record("deleteBillingKey", () -> {
-                exchange(uri, HttpMethod.DELETE, null, Void.class);
-                return null;
-            });
-            log.info("[Toss] 빌링키 삭제 성공 - billingKey: {}, elapsed: {}ms",
-                    mask(billingKey), elapsed(start));
-        } catch (Exception e) {
-            log.error("[Toss] 빌링키 삭제 실패 - billingKey: {}, elapsed: {}ms",
-                    mask(billingKey), elapsed(start), e);
-            throw e;
-        }
+        record("deleteBillingKey", () -> {
+            exchange(uri, HttpMethod.DELETE, null, Void.class);
+            return null;
+        });
+        log.info("[Toss] 빌링키 삭제 성공 - billingKey: {}, elapsed: {}ms",
+                mask(billingKey), elapsed(start));
     }
 
     private <T> T exchange(URI uri, HttpMethod method, Object body, Class<T> responseType) {
@@ -179,10 +149,9 @@ public class TossPaymentsClient {
             return restTemplate.exchange(uri, method, entity, responseType).getBody();
         } catch (HttpClientErrorException e) {
             handleClientError(e);
-            throw new InternalApiRequestException("Toss API 호출 실패: " + e.getMessage());
+            throw new InternalApiRequestException("Toss API 호출 실패", e);
         } catch (ResourceAccessException e) {
-            log.error("Toss API 네트워크 오류", e);
-            throw new InternalApiRequestException("Toss API 네트워크 오류: " + e.getMessage());
+            throw new InternalApiRequestException("Toss API 네트워크 오류", e);
         }
     }
 

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/LoggingAspectConfig.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/config/LoggingAspectConfig.java
@@ -33,7 +33,7 @@ public class LoggingAspectConfig {
                     sig, shrink(ret), (System.nanoTime() - start) / 1_000_000);
             return ret;
         } catch (Throwable t) {
-            log.error("💥 Controller error {} msg={}", sig, t.getMessage(), t);
+            log.error("💥 Controller error {}", sig, t);
             throw t;
         }
     }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/error/exception/CustomException.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/error/exception/CustomException.java
@@ -11,4 +11,9 @@ public abstract class CustomException extends RuntimeException {
         super(message);
         this.status = status;
     }
+
+    public CustomException(String message, Throwable cause, HttpStatus status) {
+        super(message, cause);
+        this.status = status;
+    }
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/error/exception/InternalApiRequestException.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/global/error/exception/InternalApiRequestException.java
@@ -8,4 +8,8 @@ public class InternalApiRequestException extends CustomException {
         super(message, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
+    public InternalApiRequestException(String message, Throwable cause) {
+        super(message, cause, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
 }

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/content/consumer/ContentOutboxConsumer.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/content/consumer/ContentOutboxConsumer.java
@@ -58,7 +58,7 @@ public class ContentOutboxConsumer {
             return true;
         } catch (Exception e) {
             outbox.markFailed(e.getMessage());
-            log.error("[OutboxWorker] 발행 실패 - id: {}, retryCount: {}, error: {}", outbox.getId(), outbox.getRetryCount(), e.getMessage());
+            log.error("[OutboxWorker] 발행 실패 - id: {}, retryCount: {}", outbox.getId(), outbox.getRetryCount(), e);
 
             // 최대 재시도 초과 시 로그 저장
             if (outbox.isExhausted()) {

--- a/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/notification/consumer/NotificationConsumer.java
+++ b/backend/src/main/java/com/keyfeed/keyfeedmonolithic/infra/notification/consumer/NotificationConsumer.java
@@ -128,7 +128,7 @@ public class NotificationConsumer {
                             .add(keyword);
                 }
             } catch (Exception e) {
-                log.error("[NotificationConsumer] SSCAN 실패 - keyword: {}, error: {}", keyword, e.getMessage());
+                log.error("[NotificationConsumer] SSCAN 실패 - keyword: {}", keyword, e);
             }
         }
 
@@ -169,7 +169,7 @@ public class NotificationConsumer {
         try {
             return objectMapper.readValue(payload, ContentEventPayload.class);
         } catch (JsonProcessingException e) {
-            log.error("[NotificationConsumer] JSON 파싱 오류 - {}", e.getMessage());
+            log.error("[NotificationConsumer] JSON 파싱 오류", e);
             return null;
         }
     }

--- a/backend/src/test/java/com/keyfeed/keyfeedmonolithic/global/logging/LoggingSpecTest.java
+++ b/backend/src/test/java/com/keyfeed/keyfeedmonolithic/global/logging/LoggingSpecTest.java
@@ -1,0 +1,48 @@
+package com.keyfeed.keyfeedmonolithic.global.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoggingSpecTest {
+
+    private static final Path MAIN_SOURCE_ROOT = Path.of("src", "main", "java");
+
+    private static final Pattern GET_MESSAGE_IN_LOG_CALL =
+            Pattern.compile("log\\.(error|warn)\\s*\\([^;]*\\b(e|ex|t|\\w*(?:Exception|Error|Throwable))\\.getMessage\\(\\)");
+
+    @Test
+    @DisplayName("log.error/warn 호출에 getMessage() 대신 예외 객체를 마지막 인자로 전달한다")
+    void 로그_호출에_예외_메시지_문자열을_전달하지_않음() throws IOException {
+        assertThat(MAIN_SOURCE_ROOT).exists();
+
+        try (Stream<Path> paths = Files.walk(MAIN_SOURCE_ROOT)) {
+            List<Path> violations = paths
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .filter(this::containsGetMessageInLogCall)
+                    .toList();
+
+            assertThat(violations)
+                    .as("log.error/warn에 getMessage()를 전달하면 스택트레이스가 유실됩니다. 예외 객체를 마지막 인자로 전달하세요: %s", violations)
+                    .isEmpty();
+        }
+    }
+
+    private boolean containsGetMessageInLogCall(Path path) {
+        try {
+            String source = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+            return GET_MESSAGE_IN_LOG_CALL.matcher(source).find();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 개요
`log.error/warn(..., e.getMessage())` 형태로 예외의 최상위 메시지 문자열만 로깅하던 패턴을 예외 객체를 마지막 인자로 전달하도록 일괄 수정합니다. SLF4J는 매칭 플레이스홀더가 없는 마지막 `Throwable` 인자를 스택트레이스로 출력하므로, 발생 위치와 `Caused by` 원인 체인이 로그에 보존됩니다.

Resolves #123

## 변경 사항

### 로그 호출 수정 (10개 파일, 20곳)
이슈에 명시된 8곳 외에, 멀티라인 호출·문자열 내 괄호 때문에 최초 grep에서 누락됐던 12곳을 함께 수정했습니다 (이슈 완료 조건인 "패턴 검색 0건" 충족 목적).

| 파일 | 수정 |
|---|---|
| `CrawlScheduler` | 1곳 |
| `RssFeedParser` | 1곳 |
| `RssFeedValidator` | 1곳 |
| `NotificationConsumer` | 2곳 |
| `TossPaymentsClient` | 6곳 |
| `SubscriptionServiceImpl` | 1곳 |
| `BillingScheduler` | 5곳 (`markFailedException` 포함) |
| `ContentOutboxConsumer` | 1곳 |
| `NotificationServiceImpl` | 1곳 |
| `LoggingAspectConfig` | 1곳 (이미 `t`를 전달 중이었으나 중복된 `msg={}` 제거) |

수정 시 예외용 잉여 플레이스홀더(`error: {}` 등)를 함께 제거해 플레이스홀더 개수를 파라미터 개수에 맞췄습니다. 예외 메시지는 스택트레이스 첫 줄에 포함되므로 정보 유실은 없습니다.

### 스코프 제외
- `TossPaymentsClient`의 `error.getMessage()` — 예외가 아닌 토스 에러 응답 DTO의 message 필드라 유지
- `markFailed(e.getMessage())`, 예외 생성자 메시지 등 로깅이 아닌 사용처 — 이슈 범위 밖
- `RobotsTxtValidator`의 `log.info` — 이슈 범위(error/warn) 밖

### 재발 방지 테스트
`LoggingSpecTest` 추가 — `src/main/java` 전체를 스캔해 `log.error/warn` 호출에 예외 변수의 `getMessage()`가 전달되는 패턴이 존재하면 실패하는 스펙 테스트 (기존 `SchedulerLockSpecTest` 컨벤션 준수).

### 중복 로깅 제거 및 로그 레벨 조정 (2차 커밋)
"예외는 처리하는 계층에서 한 번만 로깅" 원칙에 따라 정리했습니다.

- **`TossPaymentsClient` catch-log-rethrow 5곳 제거** — 클라이언트와 상위 계층(BillingScheduler, SubscriptionServiceImpl, LoggingAspect)이 같은 예외를 이중 로깅하던 문제. 모든 실패 경로가 상위에서 로깅됨을 확인했고, 실패 시 elapsed는 `toss.api.duration` 메트릭(outcome=failure)에 유지됩니다.
- **`InternalApiRequestException`에 cause 생성자 추가** — 기존에는 원인 예외를 체이닝하지 않아 클라이언트 로그를 제거하면 원인 스택이 유실되는 구조였음. cause 체이닝으로 처리 계층 로그에 `Caused by`가 전파됩니다. (부수 효과: HTTP 응답 메시지에 토스 원문 에러가 노출되던 것도 제거)
- **SSE 연결 종료 로그 강등** — 클라이언트가 브라우저를 닫을 때마다 발생하는 일상적 `IOException`이 ERROR + 풀 스택트레이스로 기록되던 것을 INFO 한 줄(emitterId + 예외 요약)로 조정.

## 검증
- `./gradlew test` 전체 테스트 통과 (신규 `LoggingSpecTest` 포함, 2차 커밋 후 재실행 통과)
- 안티패턴 멀티라인 grep 결과 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
